### PR TITLE
fix(install): stop scaffolds asserting false CI/CD and dead rule pointers

### DIFF
--- a/autopm/.claude/templates/claude-templates/addons/no-cicd.md
+++ b/autopm/.claude/templates/claude-templates/addons/no-cicd.md
@@ -1,30 +1,34 @@
 ## Project Management
 
-This project uses local development workflow without CI/CD automation.
+> **FILL IN — generated placeholder.** The installer could not determine this
+> project's CI/CD arrangement, so it made no assumption. Replace this section
+> with what is actually true: name the provider (GitHub Actions, Azure
+> Pipelines, GitLab CI, …) and how it is triggered, or state plainly that the
+> project runs no CI and verification is manual.
 
 ### Development Workflow
 
 1. **Local Development**
    - Make changes locally
-   - Run tests manually
-   - Commit when ready
+   - Run tests before pushing
+   - Keep commits small and focused
 
-2. **Manual Testing**
-   - Test changes locally before committing
-   - Use project-specific test commands
-   - Verify functionality manually
+2. **Verification**
+   - FILL IN: the commands that must pass before a change is proposed
+   - FILL IN: whether they run locally, in CI, or both
 
 3. **Deployment**
-   - Deploy manually as needed
-   - Follow project-specific deployment procedures
-   - Coordinate with team for releases
+   - FILL IN: how a change reaches production, and who triggers it
 
 ### Version Control
-```bash
-# Standard git workflow
-git add .
-git commit -m "Your message"
-git push origin main
-```
 
-Focus on code quality and manual verification before commits.
+Branch-based workflow (see the git rules and prohibitions above — direct
+commits to the default branch are not permitted):
+
+```bash
+git checkout -b feature/{description}
+git add .
+git commit -m "{type}({scope}): {description}"
+git push -u origin feature/{description}
+# Open a PR for review
+```

--- a/autopm/.claude/templates/claude-templates/base.md
+++ b/autopm/.claude/templates/claude-templates/base.md
@@ -102,7 +102,7 @@ Query Context7 before implementing|mcp://context7/[lib]/[topic]
 
 <rule id="quality" priority="HIGH">
 No partial implementations|No TODOs without tests|100% coverage for new code
-📖 .claude/rules/naming-conventions.md
+📖 .claude/rules/naming-conventions.xml
 </rule>
 
 <rule id="git" priority="MEDIUM">

--- a/install/install.js
+++ b/install/install.js
@@ -894,6 +894,51 @@ See: https://github.com/rafeekpro/ClaudeAutoPM
     return content;
   }
 
+  /**
+   * Resolve the CI/CD provider from config.
+   *
+   * Historically this read `cicd.provider` only — a key nothing in the repo
+   * ever writes, which made the github/azure/gitlab branches unreachable and
+   * silently stamped every scaffolded repo with a "no CI/CD" CLAUDE.md. We now
+   * check the keys that are actually populated, most explicit first.
+   *
+   * @returns {'github'|'azure'|'gitlab'|null} null when nothing indicates a provider
+   */
+  resolveCicdProvider(config) {
+    if (!config) return null;
+
+    const normalize = (value) => {
+      if (typeof value !== 'string') return null;
+      const v = value.trim().toLowerCase();
+      if (v === 'none' || v === 'no' || v === 'false') return null;
+      if (v.startsWith('github')) return 'github';
+      if (v.startsWith('azure')) return 'azure';
+      if (v.startsWith('gitlab')) return 'gitlab';
+      return null;
+    };
+
+    // 1. Explicit declaration wins.
+    if (typeof config.cicd?.provider === 'string') {
+      return normalize(config.cicd.provider);
+    }
+
+    // 2. The key the rest of the CLI reads/writes (bin/commands/config.js).
+    if (typeof config.features?.cicd === 'string') {
+      return normalize(config.features.cicd);
+    }
+
+    // 3. Infer from the GitHub Actions signals the config templates do set.
+    //    Unlike `kubernetes`, the github_actions block carries no `enabled`
+    //    key, so only a truthy toggle counts as evidence — an all-false block
+    //    means "no GHA features on", not "GitHub Actions is the provider".
+    if (config.features?.github_actions_k8s === true) return 'github';
+    if (config.github_actions && typeof config.github_actions === 'object') {
+      if (Object.values(config.github_actions).some(Boolean)) return 'github';
+    }
+
+    return null;
+  }
+
   getRequiredAddons() {
     const addons = [];
 
@@ -912,13 +957,17 @@ See: https://github.com/rafeekpro/ClaudeAutoPM
         addons.push('devops-agents', 'devops-workflow');
       }
 
-      if (this.currentConfig.cicd?.provider === 'github') {
-        addons.push('github-actions');
-      } else if (this.currentConfig.cicd?.provider === 'azure') {
-        addons.push('azure-devops');
-      } else if (this.currentConfig.cicd?.provider === 'gitlab') {
-        addons.push('gitlab-ci');
-      } else {
+      const cicdAddon = {
+        github: 'github-actions',
+        azure: 'azure-devops',
+        gitlab: 'gitlab-ci'
+      }[this.resolveCicdProvider(this.currentConfig)];
+
+      // An unresolved provider adds nothing: the scaffold must not assert a
+      // CI/CD arrangement it has no evidence for. `no-cicd` is opt-in only.
+      if (cicdAddon) {
+        addons.push(cicdAddon);
+      } else if (this.currentConfig.cicd?.emitPlaceholder) {
         addons.push('no-cicd');
       }
 
@@ -1137,6 +1186,62 @@ See: https://github.com/rafeekpro/ClaudeAutoPM
     }
   }
 
+  /**
+   * Basenames of the rules the given plugins currently ship.
+   */
+  collectPluginRuleNames(packagesDir, pluginNames) {
+    const names = new Set();
+
+    for (const pluginName of pluginNames) {
+      const pluginJsonPath = path.join(packagesDir, pluginName, 'plugin.json');
+      if (!fs.existsSync(pluginJsonPath)) continue;
+
+      try {
+        const metadata = JSON.parse(fs.readFileSync(pluginJsonPath, 'utf-8'));
+        for (const rule of metadata.rules || []) {
+          if (rule.file) names.add(path.basename(rule.file));
+        }
+      } catch {
+        // A malformed plugin.json is reported by the install loop below; here
+        // we just decline to treat its rules as removable.
+      }
+    }
+
+    return [...names];
+  }
+
+  /**
+   * Remove stale plugin rules from the target, preserving framework rules.
+   *
+   * The previous implementation deleted every file in `.claude/rules/`, which
+   * also removed the framework `.xml` rules installFramework() had copied
+   * moments earlier — leaving base.md and the quick-ref docs pointing at files
+   * that no longer existed. Framework-owned rules are now never deleted.
+   */
+  cleanPluginRules(pluginRuleNames = []) {
+    const rulesDir = path.join(this.targetDir, '.claude', 'rules');
+    if (!fs.existsSync(rulesDir)) return;
+
+    const frameworkRulesDir = path.join(this.autopmDir, '.claude', 'rules');
+    const frameworkRules = fs.existsSync(frameworkRulesDir)
+      ? new Set(fs.readdirSync(frameworkRulesDir))
+      : new Set();
+    const currentPluginRules = new Set(pluginRuleNames);
+
+    const stale = fs.readdirSync(rulesDir).filter(file =>
+      !frameworkRules.has(file) &&
+      !currentPluginRules.has(file) &&
+      fs.statSync(path.join(rulesDir, file)).isFile()
+    );
+
+    if (stale.length === 0) return;
+
+    this.printStep(`Removing ${stale.length} stale plugin rule(s)...`);
+    for (const file of stale) {
+      fs.unlinkSync(path.join(rulesDir, file));
+    }
+  }
+
   async installPlugins() {
     if (!this.currentConfig || !this.currentConfig.plugins) {
       this.printStep('No plugins configured for this scenario');
@@ -1159,21 +1264,10 @@ See: https://github.com/rafeekpro/ClaudeAutoPM
     const installedPlugins = [];
     const failedPlugins = [];
 
-    // Clean rules directory before installing plugins
-    // This removes old/archived rules that are no longer in plugin.json
-    const rulesDir = path.join(this.targetDir, '.claude', 'rules');
-    if (fs.existsSync(rulesDir)) {
-      const oldRules = fs.readdirSync(rulesDir);
-      if (oldRules.length > 0) {
-        this.printStep('Cleaning rules directory for fresh install...');
-        for (const file of oldRules) {
-          const filePath = path.join(rulesDir, file);
-          if (fs.statSync(filePath).isFile()) {
-            fs.unlinkSync(filePath);
-          }
-        }
-      }
-    }
+    // Drop plugin rules that are no longer shipped, keeping the framework
+    // rules installFramework() just laid down (base.md and the quick-ref docs
+    // point at those; wiping them left the pointers dangling).
+    this.cleanPluginRules(this.collectPluginRuleNames(packagesDir, pluginsToInstall));
 
     // Install each plugin directly
     for (const pluginName of pluginsToInstall) {

--- a/test/unit/install-cicd-resolution.test.js
+++ b/test/unit/install-cicd-resolution.test.js
@@ -1,0 +1,219 @@
+// CI/CD addon resolution + rules-cleanup scoping (confabulation fixes).
+//
+// Two defects this suite pins down:
+//
+// 1. getRequiredAddons() read `currentConfig.cicd.provider`, a key nothing in
+//    the repo ever writes. No config template defines it and the real schema
+//    uses `features.cicd` (bin/commands/config.js). The github/azure/gitlab
+//    branches were unreachable, so every scaffolded repo got `no-cicd` — a
+//    CLAUDE.md asserting "no CI/CD" plus "git push origin main", which also
+//    contradicts base.md's "Direct commits to main" prohibition.
+//
+// 2. installPlugins() cleaned `.claude/rules/` by deleting every file, wiping
+//    the framework `.xml` rules installFramework() had just copied. base.md
+//    and the quick-ref/agent docs then pointed at files that no longer existed.
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const Installer = require('../../install/install');
+
+const TEMPLATES_DIR = path.join(
+  __dirname, '..', '..',
+  'autopm', '.claude', 'templates', 'claude-templates'
+);
+
+function installerWith(config) {
+  const installer = new Installer();
+  installer.currentConfig = config;
+  return installer;
+}
+
+// Only the CI/CD slot matters here; the agent/workflow addons are driven by
+// unrelated config and would just add noise to every assertion.
+const CICD_ADDONS = ['github-actions', 'azure-devops', 'gitlab-ci', 'no-cicd'];
+
+function cicdAddonFor(config) {
+  return installerWith(config)
+    .getRequiredAddons()
+    .filter(addon => CICD_ADDONS.includes(addon));
+}
+
+describe('getRequiredAddons - CI/CD provider resolution', () => {
+  it('honours an explicit cicd.provider', () => {
+    expect(cicdAddonFor({ cicd: { provider: 'github' } })).toEqual(['github-actions']);
+    expect(cicdAddonFor({ cicd: { provider: 'azure' } })).toEqual(['azure-devops']);
+    expect(cicdAddonFor({ cicd: { provider: 'gitlab' } })).toEqual(['gitlab-ci']);
+  });
+
+  // The key the rest of the codebase actually writes and reads.
+  it('resolves the provider from features.cicd', () => {
+    expect(cicdAddonFor({ features: { cicd: 'github' } })).toEqual(['github-actions']);
+    expect(cicdAddonFor({ features: { cicd: 'azure' } })).toEqual(['azure-devops']);
+    expect(cicdAddonFor({ features: { cicd: 'gitlab' } })).toEqual(['gitlab-ci']);
+  });
+
+  it('accepts the platform spellings config.js displays', () => {
+    expect(cicdAddonFor({ features: { cicd: 'github-actions' } })).toEqual(['github-actions']);
+    expect(cicdAddonFor({ features: { cicd: 'azure-devops' } })).toEqual(['azure-devops']);
+    expect(cicdAddonFor({ features: { cicd: 'gitlab-ci' } })).toEqual(['gitlab-ci']);
+    expect(cicdAddonFor({ features: { cicd: 'GitHub' } })).toEqual(['github-actions']);
+  });
+
+  // Every shipped config template sets github_actions_k8s but no cicd key.
+  it('infers github from the github_actions_k8s feature flag', () => {
+    expect(cicdAddonFor({ features: { github_actions_k8s: true } })).toEqual(['github-actions']);
+  });
+
+  it('infers github from an enabled toggle in the github_actions block', () => {
+    expect(cicdAddonFor({ github_actions: { matrix_testing: true } })).toEqual(['github-actions']);
+  });
+
+  // Unlike `kubernetes`, the github_actions block has no `enabled` key, so an
+  // all-false block is absence of evidence rather than evidence of a provider.
+  it('treats an all-false github_actions block as no signal', () => {
+    expect(cicdAddonFor({
+      github_actions: {
+        kubernetes_tests: false,
+        docker_integration: false,
+        matrix_testing: false,
+        cache_optimization: false
+      }
+    })).toEqual([]);
+  });
+
+  it('emits no CI/CD addon when the provider cannot be resolved', () => {
+    // Silence is honest; a hardcoded "this project has no CI/CD" is not.
+    expect(cicdAddonFor({ features: { github_actions_k8s: false } })).toEqual([]);
+    expect(cicdAddonFor({})).toEqual([]);
+  });
+
+  it('emits no CI/CD addon when the project declares none explicitly', () => {
+    expect(cicdAddonFor({ features: { cicd: 'none' } })).toEqual([]);
+    expect(cicdAddonFor({ cicd: { provider: 'none' } })).toEqual([]);
+  });
+
+  it('still defaults to github when there is no config at all', () => {
+    const installer = new Installer();
+    installer.currentConfig = null;
+    expect(installer.getRequiredAddons()).toContain('github-actions');
+  });
+
+  // The regression that started this: every template used to land on no-cicd,
+  // because the branch keyed off `cicd.provider`, which nothing ever writes.
+  it('never emits no-cicd for a shipped config template', () => {
+    const templatesDir = path.join(
+      __dirname, '..', '..',
+      'autopm', '.claude', 'templates', 'config-templates'
+    );
+
+    const resolved = {};
+    for (const file of fs.readdirSync(templatesDir).filter(f => f.endsWith('.json'))) {
+      const config = JSON.parse(fs.readFileSync(path.join(templatesDir, file), 'utf-8'));
+      resolved[file] = cicdAddonFor(config);
+    }
+
+    expect(resolved).toEqual({
+      'docker-only.json': ['github-actions'],
+      'full-devops.json': ['github-actions'],
+      'performance.json': ['github-actions'],
+      // Every GHA toggle is false here, so the scaffold stays silent about CI.
+      'minimal.json': []
+    });
+  });
+});
+
+describe('no-cicd template honesty', () => {
+  const noCicd = fs.readFileSync(path.join(TEMPLATES_DIR, 'addons', 'no-cicd.md'), 'utf-8');
+  const base = fs.readFileSync(path.join(TEMPLATES_DIR, 'base.md'), 'utf-8');
+
+  it('does not tell the reader to push straight to main', () => {
+    // base.md lists "Direct commits to main" under ABSOLUTE PROHIBITIONS.
+    expect(base).toMatch(/Direct commits to main/);
+    expect(noCicd).not.toMatch(/push\s+origin\s+main/);
+  });
+
+  it('does not assert as fact that the project has no CI/CD', () => {
+    expect(noCicd).not.toMatch(/This project uses local development workflow without CI\/CD/i);
+  });
+
+  it('marks the unresolved provider as something the owner must fill in', () => {
+    expect(noCicd).toMatch(/FILL IN/);
+  });
+});
+
+describe('rules cleanup scoping', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'autopm-rules-clean-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function seedRules(files) {
+    const rulesDir = path.join(tmpDir, '.claude', 'rules');
+    fs.mkdirSync(rulesDir, { recursive: true });
+    for (const [name, body] of Object.entries(files)) {
+      fs.writeFileSync(path.join(rulesDir, name), body);
+    }
+    return rulesDir;
+  }
+
+  function cleanWith(pluginRuleNames) {
+    const installer = new Installer();
+    installer.targetDir = tmpDir;
+    installer.cleanPluginRules(pluginRuleNames);
+    return fs.readdirSync(path.join(tmpDir, '.claude', 'rules')).sort();
+  }
+
+  it('removes stale plugin-owned rules', () => {
+    seedRules({
+      'tdd.enforcement.md': 'current',
+      'retired-rule.md': 'stale'
+    });
+    // Only tdd.enforcement.md is still shipped by a plugin.
+    expect(cleanWith(['tdd.enforcement.md'])).toEqual(['tdd.enforcement.md']);
+  });
+
+  it('keeps framework .xml rules that base.md points at', () => {
+    seedRules({
+      'tdd.enforcement.xml': 'framework',
+      'agent-mandatory.xml': 'framework',
+      'context7.xml': 'framework',
+      'retired-rule.md': 'stale'
+    });
+
+    expect(cleanWith(['tdd.enforcement.md'])).toEqual([
+      'agent-mandatory.xml',
+      'context7.xml',
+      'tdd.enforcement.xml'
+    ]);
+  });
+
+  it('leaves the rules directory alone when it does not exist', () => {
+    const installer = new Installer();
+    installer.targetDir = tmpDir;
+    expect(() => installer.cleanPluginRules(['tdd.enforcement.md'])).not.toThrow();
+  });
+});
+
+describe('base.md rule pointers resolve after install', () => {
+  it('points only at framework rules that ship in autopm/.claude/rules', () => {
+    const base = fs.readFileSync(path.join(TEMPLATES_DIR, 'base.md'), 'utf-8');
+    const rulesDir = path.join(__dirname, '..', '..', 'autopm', '.claude', 'rules');
+
+    const pointers = [...base.matchAll(/\.claude\/rules\/([\w.-]+\.(?:xml|md))/g)]
+      .map(m => m[1]);
+
+    expect(pointers.length).toBeGreaterThan(0);
+
+    for (const pointer of pointers) {
+      expect({ pointer, exists: fs.existsSync(path.join(rulesDir, pointer)) })
+        .toEqual({ pointer, exists: true });
+    }
+  });
+});


### PR DESCRIPTION
## Problem

Generated `CLAUDE.md` files claimed things about the target repo that were not true, and pointed at rule files the installer had just deleted. Scaffolded repos inherited a false "head" describing a project that didn't exist.

### 1. Every scaffold was stamped "no CI/CD"

`getRequiredAddons()` keyed off `currentConfig.cicd.provider` — a key **nothing in this repo ever writes**. No config template defines it, and the real schema uses `features.cicd` (`bin/commands/config.js:154`).

The `github`/`azure`/`gitlab` branches were therefore **unreachable dead code**, and every scaffolded repo got the `no-cicd` addon unconditionally: a `CLAUDE.md` asserting "no CI/CD automation" plus `git push origin main` — which also contradicts `base.md`'s own `❌ Direct commits to main` prohibition, in the same generated file.

### 2. Rule pointers were dead on arrival

`installFramework()` (`:1535`) copies `autopm/.claude/rules/*.xml`. Then `installPlugins()` (`:1544`) deleted **every file** in `.claude/rules/` before reinstalling plugin rules — which ship as `.md` only. `base.md` and the quick-ref/agent docs were left pointing at files that no longer existed.

### 3. A pointer broken independently

`base.md` pointed at `naming-conventions.md`; the shipped file is `naming-conventions.xml`.

## Changes

**`install/install.js`**
- New `resolveCicdProvider()` — checks most explicit first: `cicd.provider` → `features.cicd` → `features.github_actions_k8s` → a `github_actions` block with at least one truthy toggle. Normalizes spellings (`github-actions`, `GitHub`, `azure-devops`, …); treats `none`/`no`/`false` as no provider.
- An unresolved provider now emits **no CI/CD section at all**; `no-cicd` became opt-in via `cicd.emitPlaceholder`. Silence beats a fabricated claim.
- New `cleanPluginRules()` / `collectPluginRuleNames()` replace the delete-everything loop. Stale plugin rules are still removed; framework-owned rules are never touched.

**Templates**
- `no-cicd.md` is now an explicit `FILL IN` placeholder instead of a false assertion, with the push-to-main block replaced by the branch+PR flow `base.md` already mandates.
- `base.md`: `naming-conventions` pointer corrected to `.xml`.

**Tests** — `test/unit/install-cicd-resolution.test.js`, 17 tests written RED first, including a guard that every `base.md` rule pointer resolves to a real shipped file.

## Verification

- Full suite: **55 suites, 1658 tests passed**, no regressions.
- Real install into a scratch repo: no false CI/CD claims; **70/71 rule pointers resolve** (the 71st ships with `plugin-devops`, which that preset omits).

## Note for review

`minimal.json` has every `github_actions` toggle set to `false`, so it now resolves to *no provider* and emits no CI/CD section. That's silence rather than a false claim — but if minimal projects should get GitHub Actions guidance, set `features.cicd: "github"` in that preset.

Deliberately **not** changed: the `100% coverage` / no-mocks / Context7-HIGHEST decrees in `base.md` remain absolute, per owner decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLJiSBnzwTaotvHA4VZP2W
