### PR TITLE
fix(deps): align plugin peer ranges with plugin-core 4.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10945,7 +10945,7 @@
         "npm": ">=10.0.0"
       },
       "peerDependencies": {
-        "@claudeautopm/plugin-core": "^3.0.0"
+        "@claudeautopm/plugin-core": "^4.0.0"
       }
     },
     "packages/plugin-cloud": {
@@ -10959,7 +10959,7 @@
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@claudeautopm/plugin-core": "^3.0.0"
+        "@claudeautopm/plugin-core": "^4.0.0"
       }
     },
     "packages/plugin-core": {
@@ -10979,7 +10979,7 @@
         "npm": ">=10.0.0"
       },
       "peerDependencies": {
-        "@claudeautopm/plugin-core": "^3.0.0"
+        "@claudeautopm/plugin-core": "^4.0.0"
       }
     },
     "packages/plugin-databases": {
@@ -10991,7 +10991,7 @@
         "npm": ">=10.0.0"
       },
       "peerDependencies": {
-        "@claudeautopm/plugin-core": "^3.0.0"
+        "@claudeautopm/plugin-core": "^4.0.0"
       }
     },
     "packages/plugin-devops": {
@@ -11006,7 +11006,7 @@
         "npm": ">=10.0.0"
       },
       "peerDependencies": {
-        "@claudeautopm/plugin-core": "^3.0.0"
+        "@claudeautopm/plugin-core": "^4.0.0"
       }
     },
     "packages/plugin-frameworks": {
@@ -11018,7 +11018,7 @@
         "npm": ">=10.0.0"
       },
       "peerDependencies": {
-        "@claudeautopm/plugin-core": "^3.0.0"
+        "@claudeautopm/plugin-core": "^4.0.0"
       }
     },
     "packages/plugin-languages": {
@@ -11030,7 +11030,7 @@
         "npm": ">=10.0.0"
       },
       "peerDependencies": {
-        "@claudeautopm/plugin-core": "^3.0.0"
+        "@claudeautopm/plugin-core": "^4.0.0"
       }
     },
     "packages/plugin-ml": {
@@ -11041,7 +11041,7 @@
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@claudeautopm/plugin-core": "^3.0.0"
+        "@claudeautopm/plugin-core": "^4.0.0"
       }
     },
     "packages/plugin-obsidian": {
@@ -11052,7 +11052,7 @@
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@claudeautopm/plugin-core": "^3.0.0"
+        "@claudeautopm/plugin-core": "^4.0.0"
       }
     },
     "packages/plugin-pm": {
@@ -11063,7 +11063,7 @@
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@claudeautopm/plugin-core": "^3.0.0"
+        "@claudeautopm/plugin-core": "^4.0.0"
       }
     },
     "packages/plugin-pm-azure": {
@@ -11074,7 +11074,7 @@
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@claudeautopm/plugin-core": "^3.0.0"
+        "@claudeautopm/plugin-core": "^4.0.0"
       }
     },
     "packages/plugin-pm-github": {
@@ -11085,7 +11085,7 @@
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@claudeautopm/plugin-core": "^3.0.0"
+        "@claudeautopm/plugin-core": "^4.0.0"
       }
     },
     "packages/plugin-testing": {

--- a/packages/plugin-ai/package.json
+++ b/packages/plugin-ai/package.json
@@ -61,6 +61,6 @@
     "LICENSE"
   ],
   "peerDependencies": {
-    "@claudeautopm/plugin-core": "^3.0.0"
+    "@claudeautopm/plugin-core": "^4.0.0"
   }
 }

--- a/packages/plugin-cloud/package.json
+++ b/packages/plugin-cloud/package.json
@@ -60,7 +60,7 @@
     "node": ">=22.0.0"
   },
   "peerDependencies": {
-    "@claudeautopm/plugin-core": "^3.0.0"
+    "@claudeautopm/plugin-core": "^4.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-data/package.json
+++ b/packages/plugin-data/package.json
@@ -61,6 +61,6 @@
     "LICENSE"
   ],
   "peerDependencies": {
-    "@claudeautopm/plugin-core": "^3.0.0"
+    "@claudeautopm/plugin-core": "^4.0.0"
   }
 }

--- a/packages/plugin-databases/package.json
+++ b/packages/plugin-databases/package.json
@@ -53,7 +53,7 @@
     "npm": ">=10.0.0"
   },
   "peerDependencies": {
-    "@claudeautopm/plugin-core": "^3.0.0"
+    "@claudeautopm/plugin-core": "^4.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-devops/package.json
+++ b/packages/plugin-devops/package.json
@@ -69,7 +69,7 @@
     "npm": ">=10.0.0"
   },
   "peerDependencies": {
-    "@claudeautopm/plugin-core": "^3.0.0"
+    "@claudeautopm/plugin-core": "^4.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-frameworks/package.json
+++ b/packages/plugin-frameworks/package.json
@@ -50,7 +50,7 @@
     "npm": ">=10.0.0"
   },
   "peerDependencies": {
-    "@claudeautopm/plugin-core": "^3.0.0"
+    "@claudeautopm/plugin-core": "^4.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-languages/package.json
+++ b/packages/plugin-languages/package.json
@@ -56,7 +56,7 @@
     "npm": ">=10.0.0"
   },
   "peerDependencies": {
-    "@claudeautopm/plugin-core": "^3.0.0"
+    "@claudeautopm/plugin-core": "^4.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-ml/package.json
+++ b/packages/plugin-ml/package.json
@@ -41,7 +41,7 @@
     "LICENSE"
   ],
   "peerDependencies": {
-    "@claudeautopm/plugin-core": "^3.0.0"
+    "@claudeautopm/plugin-core": "^4.0.0"
   },
   "engines": {
     "node": ">=22.0.0"

--- a/packages/plugin-obsidian/package.json
+++ b/packages/plugin-obsidian/package.json
@@ -42,7 +42,7 @@
     "node": ">=22.0.0"
   },
   "peerDependencies": {
-    "@claudeautopm/plugin-core": "^3.0.0"
+    "@claudeautopm/plugin-core": "^4.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-pm-azure/package.json
+++ b/packages/plugin-pm-azure/package.json
@@ -13,7 +13,7 @@
     "registry": "https://registry.npmjs.org"
   },
   "peerDependencies": {
-    "@claudeautopm/plugin-core": "^3.0.0"
+    "@claudeautopm/plugin-core": "^4.0.0"
   },
   "engines": {
     "node": ">=22.0.0"

--- a/packages/plugin-pm-github/package.json
+++ b/packages/plugin-pm-github/package.json
@@ -13,7 +13,7 @@
     "registry": "https://registry.npmjs.org"
   },
   "peerDependencies": {
-    "@claudeautopm/plugin-core": "^3.0.0"
+    "@claudeautopm/plugin-core": "^4.0.0"
   },
   "engines": {
     "node": ">=22.0.0"

--- a/packages/plugin-pm/package.json
+++ b/packages/plugin-pm/package.json
@@ -48,7 +48,7 @@
     "node": ">=22.0.0"
   },
   "peerDependencies": {
-    "@claudeautopm/plugin-core": "^3.0.0"
+    "@claudeautopm/plugin-core": "^4.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/test/unit/plugin-peer-versions.test.js
+++ b/test/unit/plugin-peer-versions.test.js
@@ -1,0 +1,108 @@
+/**
+ * Workspace peer-dependency consistency guard.
+ *
+ * Every plugin under packages/ that peers on @claudeautopm/plugin-core must
+ * declare a range the workspace copy of plugin-core actually satisfies. When
+ * it doesn't, `npm ci` fails with ERESOLVE and npm resolves the peer against
+ * a stale registry tarball instead of the workspace link.
+ *
+ * This broke in 2da146a ("chore(release): 4.0.0"), which bumped every plugin's
+ * `version` and `engines` but left the peer ranges at ^3.0.0. It stayed
+ * invisible for two months because every CI workflow installs with
+ * --legacy-peer-deps (.github/workflows/test.yml:29), which skips peer
+ * resolution entirely.
+ *
+ * NOT covered here on purpose: plugin.json's `compatibleWith`. That is a
+ * different axis — PluginManager compares it against the ROOT package version,
+ * not plugin-core's — and it is a `>=` range that 4.0.0 already satisfies.
+ * Tightening it to a caret range would make every plugin fail to load the
+ * moment the root package hits 5.0.0 (PluginManager.isCompatible pins majors).
+ *
+ * To fix a failure: update the peer range in the named package.json to match
+ * plugin-core's current major, then regenerate package-lock.json.
+ *
+ * Runs under both jest (npm test) and node --test (npm run test:unit).
+ */
+
+'use strict';
+
+if (typeof describe === 'undefined') {
+  // Running under node --test: provide jest-like globals.
+  const nodeTest = require('node:test');
+  globalThis.describe = nodeTest.describe;
+  globalThis.test = nodeTest.test;
+}
+
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+const PACKAGES_DIR = path.join(ROOT, 'packages');
+const CORE = '@claudeautopm/plugin-core';
+
+/** plugin-testing peers on the root package, not plugin-core — see file header. */
+const NO_CORE_PEER_EXPECTED = new Set(['plugin-testing']);
+
+function readManifest(dir) {
+  const manifestPath = path.join(PACKAGES_DIR, dir, 'package.json');
+  if (!fs.existsSync(manifestPath)) return null;
+  return JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
+}
+
+function workspacePackages() {
+  return fs.readdirSync(PACKAGES_DIR)
+    .filter(dir => fs.statSync(path.join(PACKAGES_DIR, dir)).isDirectory())
+    .filter(dir => readManifest(dir) !== null)
+    .sort();
+}
+
+/** Major from a plain version ("4.0.0") or a caret/tilde range ("^4.0.0"). */
+function majorOf(spec) {
+  const match = /^[\^~]?(\d+)\./.exec(String(spec).trim());
+  return match ? Number(match[1]) : null;
+}
+
+describe('workspace plugin peer dependencies', () => {
+  const packages = workspacePackages();
+  const coreVersion = readManifest('plugin-core')?.version;
+
+  // A filter bug that matched nothing would make every assertion below pass.
+  test('discovers the workspace packages', () => {
+    assert.ok(packages.length >= 10, `expected the plugin packages, found ${packages.length}`);
+    assert.ok(packages.includes('plugin-core'), 'plugin-core should be a workspace package');
+    assert.ok(coreVersion, 'plugin-core must declare a version');
+  });
+
+  test('every declared plugin-core peer range matches plugin-core\'s major', () => {
+    const coreMajor = majorOf(coreVersion);
+    const mismatches = [];
+
+    for (const dir of packages) {
+      const range = readManifest(dir).peerDependencies?.[CORE];
+      if (!range) continue;
+
+      if (majorOf(range) !== coreMajor) {
+        mismatches.push(`${dir}: peers on ${CORE}@"${range}" but workspace plugin-core is ${coreVersion}`);
+      }
+    }
+
+    assert.strictEqual(mismatches.join('\n'), '', `\n${mismatches.join('\n')}\n`);
+  });
+
+  test('every plugin peers on plugin-core, except known exemptions', () => {
+    const missing = packages.filter(dir =>
+      dir !== 'plugin-core' &&
+      !NO_CORE_PEER_EXPECTED.has(dir) &&
+      !readManifest(dir).peerDependencies?.[CORE]
+    );
+
+    // Catches a NEW plugin added without a peer range, while leaving the
+    // deliberate exemption visible rather than silently filtered away.
+    assert.strictEqual(missing.join(', '), '', `packages missing a ${CORE} peer: ${missing.join(', ')}`);
+  });
+
+  test('plugin-core declares no peer on itself', () => {
+    assert.ok(!readManifest('plugin-core').peerDependencies?.[CORE]);
+  });
+});


### PR DESCRIPTION
## Problem

`npm ci` fails on `develop` with `ERESOLVE`:

```
npm error Conflicting peer dependency: @claudeautopm/plugin-core@3.13.1
npm error   peer @claudeautopm/plugin-core@"^3.0.0" from @claudeautopm/plugin-ai@4.0.0
```

All twelve plugins that peer on `@claudeautopm/plugin-core` declare `^3.0.0`, while the workspace `plugin-core` is `4.0.0`. npm therefore tries to satisfy the peer by pulling the stale `plugin-core@3.13.1` tarball from the registry instead of using the workspace link.

**Introduced by** `2da146a` ("chore(release): 4.0.0 — drop Node <22 support"), which bumped each package's `version` and `engines` but left the peer ranges untouched. Broken since **2026-06-22**.

**Why CI never caught it:** every workflow that installs the root project passes `--legacy-peer-deps` — `test.yml:29`, `npm-publish.yml:17` and `:40` — which skips peer resolution entirely. The only bare `npm ci` in the repo (`deploy-docs.yml:41`) runs in `docs-site/` against a separate lockfile. There is no root `.npmrc`, so any contributor following the standard install path hits the failure.

## Changes

- Twelve peer ranges `^3.0.0` → `^4.0.0`.
- `package-lock.json` regenerated — 24 lines, no dependency drift, all workspace links preserved.
- New `test/unit/plugin-peer-versions.test.js` so a future release bump can't reintroduce this. It asserts each declared peer range matches `plugin-core`'s current major, that no plugin silently lacks a peer, and that discovery found the packages at all (a filter bug matching nothing would otherwise pass vacuously). Runs under both jest and `node --test`.

## Verification

- **Bare `npm ci` now succeeds** (no flags): `added 773 packages`, exit 0.
- `npm ls @claudeautopm/plugin-core` exits clean; every plugin deduped to `-> ./packages/plugin-core`.
- Full suite: **56 suites, 1662 tests passing.**

## Deliberately out of scope

- **`plugin.json` `compatibleWith`** (`">=3.0.0"`, 14 files) looks stale but is a *different axis*: `PluginManager` compares it against the **root package** version, not `plugin-core`'s, and `>=` already admits 4.0.0. Tightening it to a caret range would make **every plugin fail to load** once the root hits 5.0.0, since `PluginManager.isCompatible` pins majors (`lib/plugins/PluginManager.js:1483`). Left alone on purpose.
- **`plugin-testing`** peers on `claude-autopm` rather than `plugin-core` — recorded as an explicit exemption in the test rather than silently filtered.

## Follow-ups for maintainers (not in this PR)

1. **The published tarballs carry the same broken peer.** `plugin-pm@4.0.0`, `plugin-ai@4.0.0`, `plugin-obsidian@2.0.0` are live on npm with `^3.0.0`, so end users installing a plugin alongside `plugin-core@4` still hit ERESOLVE. Fixing that needs a republish via the workflow.
2. **Consider dropping `--legacy-peer-deps` from CI**, or this class of breakage stays invisible.
3. `install/post-install-check.js:341` still gates on `major >= 18` while `engines.node` is now `>=22`, and several docs pages still state a Node 16 floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLJiSBnzwTaotvHA4VZP2W
