### PR TITLE
chore(release): bump patched plugins to 4.0.1 for peer-range fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Plugin peer ranges on `@claudeautopm/plugin-core` corrected from `^3.0.0` to `^4.0.0` in the twelve plugins that declare one (PR #758). The 4.0.0 release bumped every package's `version` and `engines` but not the peer ranges, so `npm ci` failed with `ERESOLVE` — npm tried to satisfy the peer with the stale `plugin-core@3.13.1` tarball instead of the workspace link. Hidden since 2026-06-22 because every CI workflow installs with `--legacy-peer-deps`, which skips peer resolution.
+- `test/unit/plugin-peer-versions.test.js` added as a regression guard: each declared peer range must match `plugin-core`'s current major, and no plugin may silently lack a peer.
+
+### Changed
+- The twelve affected plugins bumped to `4.0.1` (`plugin-obsidian` to `2.0.1`) so the corrected peer range reaches npm. The published `4.0.0` / `2.0.0` tarballs carry the broken `^3.0.0` peer, and npm does not allow overwriting a published version — users installing a plugin alongside `plugin-core@4` hit `ERESOLVE` until these ship.
+- `plugin-core` and `plugin-testing` are deliberately **not** bumped: neither declares a `plugin-core` peer range, so their published tarballs are correct and need no republish.
+
 ## [4.0.0] - 2026-06-22
 
 **Breaking — Node.js floor raised to 22.0.0.**

--- a/package-lock.json
+++ b/package-lock.json
@@ -10938,7 +10938,7 @@
     },
     "packages/plugin-ai": {
       "name": "@claudeautopm/plugin-ai",
-      "version": "4.0.0",
+      "version": "4.0.1",
       "license": "MIT",
       "engines": {
         "node": ">=22.0.0",
@@ -10950,7 +10950,7 @@
     },
     "packages/plugin-cloud": {
       "name": "@claudeautopm/plugin-cloud",
-      "version": "4.0.0",
+      "version": "4.0.1",
       "license": "MIT",
       "devDependencies": {
         "jest": "^30.4.2"
@@ -10972,7 +10972,7 @@
     },
     "packages/plugin-data": {
       "name": "@claudeautopm/plugin-data",
-      "version": "4.0.0",
+      "version": "4.0.1",
       "license": "MIT",
       "engines": {
         "node": ">=22.0.0",
@@ -10984,7 +10984,7 @@
     },
     "packages/plugin-databases": {
       "name": "@claudeautopm/plugin-databases",
-      "version": "4.0.0",
+      "version": "4.0.1",
       "license": "MIT",
       "engines": {
         "node": ">=22.0.0",
@@ -10996,7 +10996,7 @@
     },
     "packages/plugin-devops": {
       "name": "@claudeautopm/plugin-devops",
-      "version": "4.0.0",
+      "version": "4.0.1",
       "license": "MIT",
       "devDependencies": {
         "jest": "^30.4.2"
@@ -11011,7 +11011,7 @@
     },
     "packages/plugin-frameworks": {
       "name": "@claudeautopm/plugin-frameworks",
-      "version": "4.0.0",
+      "version": "4.0.1",
       "license": "MIT",
       "engines": {
         "node": ">=22.0.0",
@@ -11023,7 +11023,7 @@
     },
     "packages/plugin-languages": {
       "name": "@claudeautopm/plugin-languages",
-      "version": "4.0.0",
+      "version": "4.0.1",
       "license": "MIT",
       "engines": {
         "node": ">=22.0.0",
@@ -11035,7 +11035,7 @@
     },
     "packages/plugin-ml": {
       "name": "@claudeautopm/plugin-ml",
-      "version": "4.0.0",
+      "version": "4.0.1",
       "license": "MIT",
       "engines": {
         "node": ">=22.0.0"
@@ -11046,7 +11046,7 @@
     },
     "packages/plugin-obsidian": {
       "name": "@claudeautopm/plugin-obsidian",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "engines": {
         "node": ">=22.0.0"
@@ -11057,7 +11057,7 @@
     },
     "packages/plugin-pm": {
       "name": "@claudeautopm/plugin-pm",
-      "version": "4.0.0",
+      "version": "4.0.1",
       "license": "MIT",
       "engines": {
         "node": ">=22.0.0"
@@ -11068,7 +11068,7 @@
     },
     "packages/plugin-pm-azure": {
       "name": "@claudeautopm/plugin-pm-azure",
-      "version": "4.0.0",
+      "version": "4.0.1",
       "license": "MIT",
       "engines": {
         "node": ">=22.0.0"
@@ -11079,7 +11079,7 @@
     },
     "packages/plugin-pm-github": {
       "name": "@claudeautopm/plugin-pm-github",
-      "version": "4.0.0",
+      "version": "4.0.1",
       "license": "MIT",
       "engines": {
         "node": ">=22.0.0"

--- a/packages/plugin-ai/package.json
+++ b/packages/plugin-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claudeautopm/plugin-ai",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Complete AI/ML plugin with OpenAI, Gemini, LangChain agents, RAG systems, model deployment, prompt engineering, and MLOps patterns for ClaudeAutoPM",
   "main": "plugin.json",
   "type": "module",

--- a/packages/plugin-cloud/package.json
+++ b/packages/plugin-cloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claudeautopm/plugin-cloud",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Complete cloud infrastructure plugin with agents for AWS, Azure, GCP, Kubernetes, Terraform, and infrastructure automation for ClaudeAutoPM",
   "main": "plugin.json",
   "type": "module",

--- a/packages/plugin-data/package.json
+++ b/packages/plugin-data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claudeautopm/plugin-data",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Complete data engineering plugin with Airflow, Kedro, LangGraph, Kafka, dbt, pandas experts, data quality rules, and example scripts for ClaudeAutoPM",
   "main": "plugin.json",
   "type": "module",

--- a/packages/plugin-databases/package.json
+++ b/packages/plugin-databases/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claudeautopm/plugin-databases",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Complete database plugin with PostgreSQL, MongoDB, Redis, BigQuery, and Cosmos DB experts, database rules, and optimization scripts for ClaudeAutoPM",
   "main": "plugin.json",
   "type": "module",

--- a/packages/plugin-devops/package.json
+++ b/packages/plugin-devops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claudeautopm/plugin-devops",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Complete DevOps plugin with agents, commands, rules, and scripts for CI/CD, Docker, GitHub, observability, and infrastructure automation for ClaudeAutoPM",
   "main": "plugin.json",
   "type": "module",

--- a/packages/plugin-frameworks/package.json
+++ b/packages/plugin-frameworks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claudeautopm/plugin-frameworks",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Complete frontend frameworks plugin with React, Vue, Tailwind CSS agents, UI commands, performance rules, and optimization scripts for ClaudeAutoPM",
   "main": "plugin.json",
   "type": "module",

--- a/packages/plugin-languages/package.json
+++ b/packages/plugin-languages/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claudeautopm/plugin-languages",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Complete programming languages plugin with Python, JavaScript, Node.js, Bash experts, language rules, and example scripts for ClaudeAutoPM",
   "main": "plugin.json",
   "type": "module",

--- a/packages/plugin-ml/package.json
+++ b/packages/plugin-ml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claudeautopm/plugin-ml",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Comprehensive Machine Learning plugin with 10 specialist agents: TensorFlow/Keras, PyTorch, RL, Scikit-learn, Neural Architecture, Gradient Boosting, Computer Vision, NLP Transformers, Time Series, and AutoML. Context7-verified patterns.",
   "main": "plugin.json",
   "scripts": {

--- a/packages/plugin-obsidian/package.json
+++ b/packages/plugin-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claudeautopm/plugin-obsidian",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Obsidian vault integration plugin for ClaudeAutoPM \u2014 sync, Dataview, Mermaid, and Excalidraw support",
   "main": "plugin.json",
   "type": "module",

--- a/packages/plugin-pm-azure/package.json
+++ b/packages/plugin-pm-azure/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claudeautopm/plugin-pm-azure",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Azure DevOps provider for ClaudeAutoPM PM system",
   "main": "plugin.json",
   "files": [

--- a/packages/plugin-pm-github/package.json
+++ b/packages/plugin-pm-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claudeautopm/plugin-pm-github",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "GitHub provider for ClaudeAutoPM PM system",
   "main": "plugin.json",
   "files": [

--- a/packages/plugin-pm/package.json
+++ b/packages/plugin-pm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claudeautopm/plugin-pm",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Complete project management plugin with PM workflows, epic management, issue tracking, and release automation for ClaudeAutoPM",
   "main": "plugin.json",
   "type": "module",


### PR DESCRIPTION
## Why a version bump is needed

PR #758 fixed the `plugin-core` peer ranges **in the repo**. It did nothing for users, because the tarballs already on npm still carry `^3.0.0`:

```
@claudeautopm/plugin-core     local=4.0.0  published=4.0.0
@claudeautopm/plugin-pm       local=4.0.0  published=4.0.0
@claudeautopm/plugin-obsidian local=2.0.0  published=2.0.0
```

npm does not allow overwriting a published version, and `plugin-publish.yml:65-69` skips any package whose local version is already on the registry. **Re-running the publish workflow against 4.0.0 would be a complete no-op** — every one of the 14 packages would hit the skip branch. Reaching end users requires new version numbers.

## Changes

- Twelve plugins `4.0.0` → `4.0.1` — exactly the set whose `package.json` changed in #758.
- `plugin-obsidian` `2.0.0` → `2.0.1`, staying on its own version line (deliberate since it was scaffolded at `1.x`; see `CHANGELOG.md:19`).
- `package-lock.json` refreshed; `CHANGELOG.md` entry added under Unreleased.

**`plugin-core` and `plugin-testing` are deliberately not bumped.** Neither declares a `plugin-core` peer range, so neither changed in #758 and both published tarballs are already correct. Bumping them would publish byte-identical content under a new version for no reason.

## This PR does not publish

`plugin-publish.yml` is `workflow_dispatch` only. After merge, someone has to deliberately run:

```
gh workflow run plugin-publish.yml -f plugin=all
```

I have not run it and will not without an explicit instruction. The 12 bumped packages will publish; the 2 unbumped ones will correctly skip.

## Verification

- Bare `npm ci` (no `--legacy-peer-deps`): exit 0.
- `npm ls @claudeautopm/plugin-core`: exit 0, every plugin deduped to `-> ./packages/plugin-core`.
- Full suite: **56 suites, 1662 tests passing.**
- Diff is exactly one line per package.json — verified with `git diff --numstat`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLJiSBnzwTaotvHA4VZP2W
