### PR TITLE
fix(azure): call API methods that actually exist on the client

### DIFF
--- a/.claude/providers/azure/lib/client.js
+++ b/.claude/providers/azure/lib/client.js
@@ -165,7 +165,7 @@ class AzureDevOpsClient {
       team: this.team
     };
 
-    return await work.getCapacities(
+    return await work.getCapacitiesWithIdentityRefAndTotals(
       teamContext,
       iteration.id
     );

--- a/autopm/.claude/providers/azure/lib/client.js
+++ b/autopm/.claude/providers/azure/lib/client.js
@@ -165,7 +165,7 @@ class AzureDevOpsClient {
       team: this.team
     };
 
-    return await work.getCapacities(
+    return await work.getCapacitiesWithIdentityRefAndTotals(
       teamContext,
       iteration.id
     );

--- a/lib/providers/AzureDevOpsProvider.js
+++ b/lib/providers/AzureDevOpsProvider.js
@@ -41,6 +41,7 @@ class AzureDevOpsProvider {
 
     this.connection = null;
     this.witApi = null;
+    this.coreApi = null;
   }
 
   /**
@@ -78,8 +79,11 @@ class AzureDevOpsProvider {
     // Get Work Item Tracking API
     this.witApi = await this.connection.getWorkItemTrackingApi();
 
+    // Project lookup lives on the Core API, not Work Item Tracking.
+    this.coreApi = await this.connection.getCoreApi();
+
     // Verify project access
-    const project = await this.witApi.getProject(this.project);
+    const project = await this.coreApi.getProject(this.project);
     if (!project) {
       throw new Error('Project not found or access denied');
     }

--- a/test/__mocks__/azure-devops-node-api.js
+++ b/test/__mocks__/azure-devops-node-api.js
@@ -12,9 +12,11 @@ const defaultProject = {
   description: 'Test Project'
 };
 
-// Create the mock WIT API
+// Create the mock WIT API.
+// NOTE: only methods that genuinely exist on WorkItemTrackingApi belong here.
+// getProject lives on CoreApi — mocking it here previously made a broken
+// authenticate() look correct in every test. See test/unit/azure-api-surface.test.js.
 const mockWorkItemTrackingApi = {
-  getProject: jest.fn(),
   getWorkItem: jest.fn(),
   getWorkItems: jest.fn(),
   createWorkItem: jest.fn(),
@@ -27,11 +29,17 @@ const mockWorkItemTrackingApi = {
   queryByWiql: jest.fn()
 };
 
-// Set default resolved value for getProject
-mockWorkItemTrackingApi.getProject.mockResolvedValue(defaultProject);
+// Create the mock Core API (project lookup lives here).
+const mockCoreApi = {
+  getProject: jest.fn(),
+  getProjects: jest.fn()
+};
+
+mockCoreApi.getProject.mockResolvedValue(defaultProject);
 
 const mockWebApi = jest.fn().mockImplementation(() => ({
-  getWorkItemTrackingApi: jest.fn().mockResolvedValue(mockWorkItemTrackingApi)
+  getWorkItemTrackingApi: jest.fn().mockResolvedValue(mockWorkItemTrackingApi),
+  getCoreApi: jest.fn().mockResolvedValue(mockCoreApi)
 }));
 
 const mockPersonalAccessTokenHandler = jest.fn().mockImplementation((token) => ({
@@ -42,7 +50,7 @@ const mockPersonalAccessTokenHandler = jest.fn().mockImplementation((token) => (
 
 // Export a reset function to restore default mocks
 const resetMocks = () => {
-  mockWorkItemTrackingApi.getProject.mockResolvedValue(defaultProject);
+  mockCoreApi.getProject.mockResolvedValue(defaultProject);
 };
 
 module.exports = {
@@ -50,5 +58,6 @@ module.exports = {
   getPersonalAccessTokenHandler: mockPersonalAccessTokenHandler,
   // Export the mock API for direct access in tests
   __mockWorkItemTrackingApi: mockWorkItemTrackingApi,
+  __mockCoreApi: mockCoreApi,
   __resetMocks: resetMocks
 };

--- a/test/jest-tests/azure-lib-client-jest.test.js
+++ b/test/jest-tests/azure-lib-client-jest.test.js
@@ -43,7 +43,7 @@ describe('AzureDevOpsClient', () => {
 
     mockWorkApi = {
       getTeamIterations: jest.fn(),
-      getCapacities: jest.fn()
+      getCapacitiesWithIdentityRefAndTotals: jest.fn()
     };
 
     // Mock connection
@@ -394,12 +394,12 @@ describe('AzureDevOpsClient', () => {
       const mockCapacity = [{ teamMember: { displayName: 'User 1' }, activities: [] }];
 
       mockWorkApi.getTeamIterations.mockResolvedValue([mockIteration]);
-      mockWorkApi.getCapacities.mockResolvedValue(mockCapacity);
+      mockWorkApi.getCapacitiesWithIdentityRefAndTotals.mockResolvedValue(mockCapacity);
 
       const result = await client.getTeamCapacity();
 
       expect(result).toBe(mockCapacity);
-      expect(mockWorkApi.getCapacities).toHaveBeenCalledWith(
+      expect(mockWorkApi.getCapacitiesWithIdentityRefAndTotals).toHaveBeenCalledWith(
         { project: 'test-project', team: 'test-team' },
         'iter1'
       );

--- a/test/unit/azure-api-surface.test.js
+++ b/test/unit/azure-api-surface.test.js
@@ -1,0 +1,102 @@
+/**
+ * Azure DevOps API surface guard.
+ *
+ * Every method we call on an azure-devops-node-api client must actually exist
+ * on that client's prototype. The existing Azure suites all mock the library
+ * wholesale (`jest.mock('azure-devops-node-api')`), so a call to a method the
+ * library has never exported passes every test and fails only at runtime.
+ *
+ * That is not hypothetical — it is how two live TypeErrors survived:
+ *   - AzureDevOpsProvider.authenticate() called witApi.getProject(), which is
+ *     on CoreApi, not WorkItemTrackingApi. Azure auth threw on every call.
+ *   - client.getTeamCapacity() called work.getCapacities(), which no version
+ *     of the library has ever exported.
+ *
+ * This test reads the real source, extracts the methods invoked on each API
+ * handle, and checks them against the installed library's prototypes. It
+ * discovers calls rather than restating a hand-written list, so a new bad call
+ * is caught without anyone remembering to update this file.
+ *
+ * Runs under both jest (npm test) and node --test (npm run test:unit).
+ */
+
+'use strict';
+
+if (typeof describe === 'undefined') {
+  // Running under node --test: provide jest-like globals.
+  const nodeTest = require('node:test');
+  globalThis.describe = nodeTest.describe;
+  globalThis.test = nodeTest.test;
+}
+
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+
+const PROTOTYPES = {
+  WorkItemTracking: require('azure-devops-node-api/WorkItemTrackingApi').WorkItemTrackingApi.prototype,
+  Work: require('azure-devops-node-api/WorkApi').WorkApi.prototype,
+  Core: require('azure-devops-node-api/CoreApi').CoreApi.prototype
+};
+
+/**
+ * Source files and the local variable each API handle is bound to.
+ * `wit`/`witApi` -> WorkItemTracking, `work` -> Work, `core`/`coreApi` -> Core.
+ */
+const SOURCES = [
+  {
+    file: 'autopm/.claude/providers/azure/lib/client.js',
+    handles: { wit: 'WorkItemTracking', work: 'Work', core: 'Core', coreApi: 'Core' }
+  },
+  {
+    file: '.claude/providers/azure/lib/client.js',
+    handles: { wit: 'WorkItemTracking', work: 'Work', core: 'Core', coreApi: 'Core' }
+  },
+  {
+    file: 'lib/providers/AzureDevOpsProvider.js',
+    handles: { witApi: 'WorkItemTracking', workApi: 'Work', coreApi: 'Core' }
+  }
+];
+
+/** Methods invoked on the given handles, as [handle, method] pairs. */
+function callsIn(source, handles) {
+  const names = Object.keys(handles).sort((a, b) => b.length - a.length).join('|');
+  const pattern = new RegExp(`\\b(${names})\\.(\\w+)\\s*\\(`, 'g');
+
+  const calls = new Set();
+  for (const match of source.matchAll(pattern)) {
+    calls.add(`${match[1]}.${match[2]}`);
+  }
+  return [...calls].sort();
+}
+
+describe('azure-devops-node-api call sites', () => {
+  for (const { file, handles } of SOURCES) {
+    const abs = path.join(ROOT, file);
+
+    describe(file, () => {
+      const exists = fs.existsSync(abs);
+      const calls = exists ? callsIn(fs.readFileSync(abs, 'utf-8'), handles) : [];
+
+      // A regex that matched nothing would make the assertion below vacuous.
+      test('source exists and API calls were discovered', () => {
+        assert.ok(exists, `${file} not found`);
+        assert.ok(calls.length > 0, `no API calls discovered in ${file}`);
+      });
+
+      test('every called method exists on the real client', () => {
+        const missing = calls.filter(call => {
+          const [handle, method] = call.split('.');
+          return typeof PROTOTYPES[handles[handle]][method] !== 'function';
+        }).map(call => {
+          const [handle, method] = call.split('.');
+          return `${call}() — ${handles[handle]}Api has no ${method}()`;
+        });
+
+        assert.strictEqual(missing.join('\n'), '', `\n${missing.join('\n')}\n`);
+      });
+    });
+  }
+});

--- a/test/unit/providers/AzureDevOpsProvider-jest.test.js
+++ b/test/unit/providers/AzureDevOpsProvider-jest.test.js
@@ -26,6 +26,7 @@ const azdev = require('azure-devops-node-api');
 describe('AzureDevOpsProvider', () => {
   let provider;
   let mockWitApi;
+  let mockCoreApi;
 
   beforeEach(() => {
     // Clear all mocks before each test
@@ -38,6 +39,8 @@ describe('AzureDevOpsProvider', () => {
 
     // Get reference to mock WIT API
     mockWitApi = azdev.__mockWorkItemTrackingApi;
+    // Project lookup is a Core API call, not Work Item Tracking.
+    mockCoreApi = azdev.__mockCoreApi;
 
     // Restore default mock implementations
     azdev.__resetMocks();
@@ -143,7 +146,7 @@ describe('AzureDevOpsProvider', () => {
 
       await provider.authenticate();
 
-      expect(mockWitApi.getProject).toHaveBeenCalledWith('test-project');
+      expect(mockCoreApi.getProject).toHaveBeenCalledWith('test-project');
     });
 
     test('should throw error if project not found', async () => {
@@ -153,7 +156,7 @@ describe('AzureDevOpsProvider', () => {
         project: 'nonexistent-project'
       });
 
-      mockWitApi.getProject.mockResolvedValue(null);
+      mockCoreApi.getProject.mockResolvedValue(null);
 
       await expect(provider.authenticate()).rejects.toThrow(
         'Project not found or access denied'


### PR DESCRIPTION
## Two live TypeErrors

Both were invisible because every Azure suite mocks `azure-devops-node-api` wholesale, so the tests asserted against methods the library never exported.

### 1. Azure DevOps authentication was completely broken

`lib/providers/AzureDevOpsProvider.js:82` called `this.witApi.getProject(this.project)`. `getProject` is on **CoreApi**, not `WorkItemTrackingApi`:

```
WorkItemTrackingApi.getProject: undefined
CoreApi.getProject:            function
```

This is in `authenticate()` — the first thing that runs — so every Azure DevOps authentication threw `TypeError: this.witApi.getProject is not a function`. The provider could not authenticate at all.

**Fix:** fetch a Core API handle and call `getProject` there.

### 2. `getTeamCapacity()` called a method that has never existed

`providers/azure/lib/client.js:168` called `work.getCapacities()`. I checked both **16.0.0 and 17.0.0** — no version of the library exports it. The real method is `getCapacitiesWithIdentityRefAndTotals(teamContext, iterationId)`: identical signature, returns `TeamCapacity`.

Fixed in both the payload copy and the installed `.claude` mirror, which remain byte-identical.

## Why this survived every test

`test/__mocks__/azure-devops-node-api.js` defined `getProject` on the mock WIT API. The mock was a fiction that made the broken call look correct, and every assertion agreed with it.

The mock now mirrors the real client — `getProject` moved to a mock `CoreApi`, exposed as `__mockCoreApi` — so it can no longer bless a call the library cannot serve.

## The regression guard

`test/unit/azure-api-surface.test.js` reads the real source, extracts the methods invoked on each API handle (`wit`/`witApi`, `work`, `core`/`coreApi`), and checks each against the installed library's prototypes.

It **discovers calls by parsing** rather than restating a hand-written list, so a future bad call is caught without anyone remembering to update the test. It also asserts the discovery itself found something, so a broken regex can't make it pass vacuously.

This is the guard the mocked suites structurally cannot provide: no amount of mocking can tell you a method doesn't exist upstream. Running it against the unfixed code produces exactly the two failures above.

## Verification

- Full suite: **57 suites, 1668 tests passing.**
- Also ran `test/jest-tests/azure-lib-client-jest.test.js` (31 tests) — it is outside the default `testMatch`, which is part of why bug 2 hid.
- New test passes under both jest and `node --test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLJiSBnzwTaotvHA4VZP2W
