### PR TITLE
chore(ci): install with plain `npm ci`, without --legacy-peer-deps

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/setup-node@v7
         with:
           node-version: '22'
-      - run: npm ci --legacy-peer-deps
+      - run: npm ci
       - run: npm test
 
   publish:
@@ -37,7 +37,7 @@ jobs:
       # path. Note: this swaps only the npm binary — the auth config written
       # by setup-node lives in $NPM_CONFIG_USERCONFIG and is unaffected.
       - run: npm install -g npm@11.16.0 --ignore-scripts
-      - run: npm ci --legacy-peer-deps
+      - run: npm ci
       # Tests gate this job via `needs: test` above — a red suite never
       # reaches publish. NODE_AUTH_TOKEN kept as a fallback: with a Trusted
       # Publisher configured on npmjs.com, npm >= 11.5.1 uses OIDC; until

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
         cache: 'npm'
 
     - name: Install dependencies
-      run: npm ci --legacy-peer-deps
+      run: npm ci
 
     - name: Lint JavaScript
       run: npm run lint:js

--- a/test/unit/ci-install-flags.test.js
+++ b/test/unit/ci-install-flags.test.js
@@ -1,0 +1,87 @@
+/**
+ * CI dependency-install guard.
+ *
+ * Workflows must install with a plain `npm ci`. `--legacy-peer-deps` disables
+ * peer-dependency resolution outright, so a genuinely broken dependency tree
+ * still installs green.
+ *
+ * That is not theoretical. Every plugin declared `peerDependencies` on
+ * @claudeautopm/plugin-core at "^3.0.0" while plugin-core was 4.0.0, which
+ * made `npm ci` fail with ERESOLVE for two months (2026-06-22 → 2026-08-30,
+ * PR #758). CI never noticed, because every workflow passed the flag.
+ *
+ * If this test fails, fix the dependency conflict — do not re-add the flag to
+ * silence it. The whole point is that the conflict becomes visible.
+ *
+ * Runs under both jest (npm test) and node --test (npm run test:unit).
+ */
+
+'use strict';
+
+if (typeof describe === 'undefined') {
+  // Running under node --test: provide jest-like globals.
+  const nodeTest = require('node:test');
+  globalThis.describe = nodeTest.describe;
+  globalThis.test = nodeTest.test;
+}
+
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const WORKFLOWS_DIR = path.resolve(__dirname, '..', '..', '.github', 'workflows');
+
+function workflowFiles() {
+  if (!fs.existsSync(WORKFLOWS_DIR)) return [];
+  return fs.readdirSync(WORKFLOWS_DIR)
+    .filter(f => f.endsWith('.yml') || f.endsWith('.yaml'))
+    .sort();
+}
+
+/** Lines that are actual run steps, not comments. */
+function runLines(source) {
+  return source.split('\n')
+    .map((text, i) => ({ line: i + 1, text }))
+    .filter(({ text }) => !/^\s*#/.test(text));
+}
+
+describe('CI dependency install', () => {
+  const files = workflowFiles();
+
+  // A bad path or filter would make the assertions below vacuous.
+  test('discovers the workflow files', () => {
+    assert.ok(files.length > 0, `no workflows found in ${WORKFLOWS_DIR}`);
+    assert.ok(files.includes('test.yml'), 'test.yml should exist');
+  });
+
+  test('no workflow installs with --legacy-peer-deps', () => {
+    const offenders = [];
+
+    for (const file of files) {
+      const source = fs.readFileSync(path.join(WORKFLOWS_DIR, file), 'utf-8');
+      for (const { line, text } of runLines(source)) {
+        if (text.includes('--legacy-peer-deps')) {
+          offenders.push(`${file}:${line}: ${text.trim()}`);
+        }
+      }
+    }
+
+    assert.strictEqual(offenders.join('\n'), '', `\n${offenders.join('\n')}\n`);
+  });
+
+  test('no workflow installs with --force', () => {
+    const offenders = [];
+
+    for (const file of files) {
+      const source = fs.readFileSync(path.join(WORKFLOWS_DIR, file), 'utf-8');
+      for (const { line, text } of runLines(source)) {
+        // --force on an install suppresses the same class of conflict.
+        if (/npm\s+(ci|install|i)\b[^\n]*--force/.test(text)) {
+          offenders.push(`${file}:${line}: ${text.trim()}`);
+        }
+      }
+    }
+
+    assert.strictEqual(offenders.join('\n'), '', `\n${offenders.join('\n')}\n`);
+  });
+});


### PR DESCRIPTION
## Why

`--legacy-peer-deps` disables peer-dependency resolution outright, so a genuinely broken dependency tree still installs green.

That's not theoretical — it's precisely what happened. Every plugin declared a peer on `@claudeautopm/plugin-core` at `^3.0.0` while `plugin-core` was `4.0.0`, breaking `npm ci` from **2026-06-22 until PR #758**. Two months, and CI stayed green the whole time because all three install sites passed the flag.

## Changes

Dropped from the three call sites:

| File | Job |
|---|---|
| `.github/workflows/test.yml:29` | the PR/push gate |
| `.github/workflows/npm-publish.yml:17` | test job |
| `.github/workflows/npm-publish.yml:40` | publish job |

`deploy-docs.yml:41` already used a plain `npm ci`. The `npm install -g npm@...` steps install npm itself and are unrelated.

## Why it's safe to drop now

With #758 and #759 landed, bare `npm ci` resolves cleanly on `develop` — verified locally, exit 0, and `npm ls @claudeautopm/plugin-core` exits clean with every plugin deduped to the workspace copy. There's no root `.npmrc` that would reintroduce the flag.

**This PR's own CI is the real proof.** `test.yml` now runs a plain `npm ci` on Node 22.x and 24.x — if anything else was hiding behind the flag, these checks fail here rather than in a future release.

## The guard

`test/unit/ci-install-flags.test.js` stops the flag quietly returning. It also rejects `npm ci/install --force`, which suppresses the same class of conflict, and asserts it actually found workflow files so a bad path can't make it pass vacuously.

If it fails, the fix is to resolve the dependency conflict — not to re-add the flag. That's stated in the test header.

## One real change in failure mode

`npm-publish.yml:40` is the **publish** job. A future unresolved peer conflict will now block a release rather than shipping from an unverified tree. That's the intent, but it's a genuine behavioural change worth knowing about: releases can now fail at install where previously they wouldn't.

## Verification

- Full suite: **58 suites, 1671 tests passing.**
- New test passes under both jest and `node --test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLJiSBnzwTaotvHA4VZP2W
