### PR TITLE
chore: close remaining cleanup items from the docs/deps sweep

### DIFF
--- a/FRAMEWORK-GUIDE.md
+++ b/FRAMEWORK-GUIDE.md
@@ -184,8 +184,8 @@ After ClaudeAutoPM:
 
 ### Prerequisites
 
-- **Node.js**: >= 16.0.0
-- **npm**: >= 8.0.0
+- **Node.js**: >= 22.0.0
+- **npm**: >= 10.0.0
 - **Git**: Latest version
 - **Claude Code**: Desktop app or CLI access
 - **Docker** (optional): For containerized development

--- a/docs-site/docs/.vitepress/config.ts
+++ b/docs-site/docs/.vitepress/config.ts
@@ -8,13 +8,15 @@ export default defineConfig({
   // Without this every absolute asset and link 404s in production.
   base: '/ClaudeAutoPM/',
 
-  head: [
-    ['link', { rel: 'icon', href: '/favicon.ico' }]
-  ],
+  // No favicon/logo asset ships with this repo, so the previous
+  // head icon link and themeConfig.logo both 404'd in production.
+  // To restore: drop the real files into docs-site/docs/public/ and re-add
+  //   head: [['link', { rel: 'icon', href: '/ClaudeAutoPM/favicon.ico' }]]
+  //   themeConfig.logo: '/logo.svg'
+  // Note the asymmetry: `base` is NOT prepended to raw `head` tags (spell it
+  // out there), but IS prepended to themeConfig.logo (keep that root-relative).
 
   themeConfig: {
-    logo: '/logo.svg',
-
     nav: [
       { text: 'Guide', link: '/getting-started/' },
       { text: 'User Guide', link: '/user-guide/' },

--- a/docs-site/docs/developer-guide/architecture.md
+++ b/docs-site/docs/developer-guide/architecture.md
@@ -1,17 +1,17 @@
 ---
 title: Architecture
-description: ClaudeAutoPM v3.14.0 project architecture, plugin system, providers, and XML rules
+description: ClaudeAutoPM v4.0.0 project architecture, plugin system, providers, and XML rules
 ---
 
 # Project Architecture
 
-ClaudeAutoPM v3.14.0 follows a plugin-based architecture with 13 npm packages, a provider router for issue tracking, and an XML rules system for token-efficient context loading.
+ClaudeAutoPM v4.0.0 follows a plugin-based architecture with 13 npm packages, a provider router for issue tracking, and an XML rules system for token-efficient context loading.
 
 ## High-Level Overview
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
-│                     ClaudeAutoPM v3.14.0                        │
+│                     ClaudeAutoPM v4.0.0                         │
 ├─────────────────────────────────────────────────────────────────┤
 │  CLI Layer (bin/)                                               │
 │  ├── autopm.js (main entry point)                               │

--- a/docs-site/docs/developer-guide/contributing.md
+++ b/docs-site/docs/developer-guide/contributing.md
@@ -56,8 +56,8 @@ Want to contribute?
 
 ### Prerequisites
 
-- Node.js >= 16.0.0
-- npm >= 8.0.0
+- Node.js >= 22.0.0
+- npm >= 10.0.0
 - Git
 - Claude Code CLI (for testing)
 

--- a/docs-site/docs/developer-guide/index.md
+++ b/docs-site/docs/developer-guide/index.md
@@ -84,8 +84,8 @@ Use specialized agents for complex tasks rather than direct tool calls:
 
 ### Prerequisites
 
-- Node.js >= 16.0.0
-- npm >= 8.0.0
+- Node.js >= 22.0.0
+- npm >= 10.0.0
 - Git
 - Claude Code CLI (for testing agents)
 

--- a/docs-site/docs/developer-guide/plugin-development.md
+++ b/docs-site/docs/developer-guide/plugin-development.md
@@ -261,7 +261,7 @@ Hook types: `pre-command`, `pre-agent`, `pre-tool`, `wrapper`, `testing`, `docum
     "README.md"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   }
 }
 ```

--- a/docs-site/docs/getting-started/index.md
+++ b/docs-site/docs/getting-started/index.md
@@ -84,8 +84,8 @@ PRD (Requirements) → Epic (Technical Plan) → Tasks → GitHub Issues → Cod
 
 Before you begin, ensure you have:
 
-- **Node.js** >= 16.0.0
-- **npm** >= 8.0.0
+- **Node.js** >= 22.0.0
+- **npm** >= 10.0.0
 - **Git** installed and configured
 - **Claude Code** or compatible AI coding assistant
 - **GitHub CLI** (optional, installed automatically during setup)

--- a/docs-site/docs/getting-started/installation.md
+++ b/docs-site/docs/getting-started/installation.md
@@ -1,11 +1,11 @@
 ---
 title: Installation
-description: Complete installation guide for ClaudeAutoPM v3.14.0 with all scenarios and configuration options
+description: Complete installation guide for ClaudeAutoPM v4.0.0 with all scenarios and configuration options
 ---
 
 # Installation Guide
 
-This guide covers npm/npx installation methods and configuration options for ClaudeAutoPM v3.14.0. For the shell-based installer, see `install/install.sh`.
+This guide covers npm/npx installation methods and configuration options for ClaudeAutoPM v4.0.0. For the shell-based installer, see `install/install.sh`.
 
 ## System Requirements
 
@@ -13,8 +13,8 @@ This guide covers npm/npx installation methods and configuration options for Cla
 
 | Requirement | Minimum Version |
 |-------------|-----------------|
-| Node.js | >= 16.0.0 (>= 18.0.0 recommended; plugins require 18+) |
-| npm | >= 8.0.0 |
+| Node.js | >= 22.0.0 |
+| npm | >= 10.0.0 |
 | Git | Latest stable |
 
 ### Platform Support

--- a/docs-site/docs/index.md
+++ b/docs-site/docs/index.md
@@ -6,7 +6,7 @@ markdownStyles: false
 hero:
   name: "ClaudeAutoPM"
   text: "Plugin-Based AI Project Management"
-  tagline: Ship faster with spec-driven development, 7 core agents, and 13 optional plugins — v3.14.0
+  tagline: Ship faster with spec-driven development, 7 core agents, and 13 optional plugins — v4.0.0
   actions:
     - theme: brand
       text: Get Started

--- a/docs-site/docs/reference/troubleshooting.md
+++ b/docs-site/docs/reference/troubleshooting.md
@@ -85,7 +85,7 @@ npm install -g claude-autopm@latest
 
 **Problem**: `Node.js version not supported` error
 
-**Requirements**: Node.js ≥ 16.0.0, npm ≥ 8.0.0
+**Requirements**: Node.js ≥ 22.0.0, npm ≥ 10.0.0
 
 **Solution**:
 ```bash

--- a/docs-site/docs/user-guide/pm-workflow.md
+++ b/docs-site/docs/user-guide/pm-workflow.md
@@ -1,6 +1,6 @@
 ---
 title: PM Workflow
-description: Complete project management workflow using ClaudeAutoPM v3.14.0 with local, GitHub, and Azure providers.
+description: Complete project management workflow using ClaudeAutoPM v4.0.0 with local, GitHub, and Azure providers.
 ---
 
 # PM Workflow

--- a/install/post-install-check.js
+++ b/install/post-install-check.js
@@ -339,18 +339,18 @@ class PostInstallChecker {
   checkNodeVersion() {
     const version = process.version;
     const major = parseInt(version.split('.')[0].substring(1));
-    const isSupported = major >= 18;
+    const isSupported = major >= 22;
 
     this.results.optional.push({
       name: 'Node.js version',
       status: isSupported,
       message: isSupported
         ? `${version} (supported)`
-        : `${version} (upgrade recommended)`
+        : `${version} (unsupported - requires v22 or higher)`
     });
 
     if (!isSupported) {
-      this.results.nextSteps.push('Upgrade Node.js to v18 or higher');
+      this.results.nextSteps.push('Upgrade Node.js to v22 or higher');
     }
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,6 @@
         "@types/jest": "^30.0.0",
         "axios": "^1.12.2",
         "c8": "^12.0.0",
-        "chai": "^6.0.1",
         "eslint": "^10.6.0",
         "globals": "^17.6.0",
         "jest": "^30.1.3",
@@ -56,8 +55,7 @@
         "jest-watch-typeahead": "^3.0.1",
         "markdownlint-cli": "^0.49.0",
         "nock": "^14.0.10",
-        "prettier": "^3.0.0",
-        "sinon": "^22.0.0"
+        "prettier": "^3.0.0"
       },
       "engines": {
         "node": ">=22.0.0",
@@ -2361,27 +2359,6 @@
         "@sinonjs/commons": "^3.0.1"
       }
     },
-    "node_modules/@sinonjs/samsam": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-10.0.2.tgz",
-      "integrity": "sha512-8lVwD1Df1BmzoaOLhMcGGcz/Jyr5QY2KSB75/YK1QgKzoabTeLdIVyhXNZK9ojfSKSdirbXqdbsXXqP9/Ve8+A==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sinonjs/commons": "^3.0.1",
-        "type-detect": "^4.1.0"
-      }
-    },
-    "node_modules/@sinonjs/samsam/node_modules/type-detect": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
-      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/@stablelib/base64": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
@@ -3691,16 +3668,6 @@
         }
       ],
       "license": "CC-BY-4.0"
-    },
-    "node_modules/chai": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
-      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -9622,33 +9589,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/steveukx/git-js?sponsor=1"
-      }
-    },
-    "node_modules/sinon": {
-      "version": "22.1.0",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-22.1.0.tgz",
-      "integrity": "sha512-n1ajF2rBWMTtEwbKcw4UdFg4nCnDdq/U6RDoxtOd7oapOlRoJ5ynwFx60owROyhDpA9QhMZi0pCO/xtmwFjG7w==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sinonjs/commons": "^3.0.1",
-        "@sinonjs/fake-timers": "^15.4.0",
-        "@sinonjs/samsam": "^10.0.2",
-        "diff": "^9.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/sinon"
-      }
-    },
-    "node_modules/sinon/node_modules/diff": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
-      "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
       }
     },
     "node_modules/slash": {

--- a/package.json
+++ b/package.json
@@ -160,7 +160,6 @@
     "@types/jest": "^30.0.0",
     "axios": "^1.12.2",
     "c8": "^12.0.0",
-    "chai": "^6.0.1",
     "eslint": "^10.6.0",
     "globals": "^17.6.0",
     "jest": "^30.1.3",
@@ -171,8 +170,7 @@
     "jest-watch-typeahead": "^3.0.1",
     "markdownlint-cli": "^0.49.0",
     "nock": "^14.0.10",
-    "prettier": "^3.0.0",
-    "sinon": "^22.0.0"
+    "prettier": "^3.0.0"
   },
   "optionalDependencies": {
     "@playwright/mcp": "^0.0.79",

--- a/packages/plugin-ai/README.md
+++ b/packages/plugin-ai/README.md
@@ -274,8 +274,8 @@ with mlflow.start_run():
 
 ## Requirements
 
-- **Node.js**: >=16.0.0
-- **npm**: >=8.0.0
+- **Node.js**: >=22.0.0
+- **npm**: >=10.0.0
 - **Python**: >=3.8 (for example scripts)
 - **API Keys**: OpenAI, Gemini (as needed)
 

--- a/packages/plugin-core/README.md
+++ b/packages/plugin-core/README.md
@@ -252,7 +252,7 @@ No configuration needed - all core features are always enabled.
 ## Compatibility
 
 - **Minimum ClaudeAutoPM version:** 3.0.0
-- **Node.js:** >= 18.0.0
+- **Node.js:** >= 22.0.0
 - **Platform:** Cross-platform (macOS, Linux, Windows)
 
 ---

--- a/packages/plugin-pm/README.md
+++ b/packages/plugin-pm/README.md
@@ -359,7 +359,7 @@ MIT © ClaudeAutoPM Team
 
 ## 🎯 Compatibility
 
-- **Node.js:** >= 16.0.0
+- **Node.js:** >= 22.0.0
 - **ClaudeAutoPM:** >= 3.0.0
 - **Plugin Core:** ^2.0.0
 

--- a/test/jest-tests/post-install-check-jest.test.js
+++ b/test/jest-tests/post-install-check-jest.test.js
@@ -398,8 +398,11 @@ describe('PostInstallChecker', () => {
 
       const nodeCheck = checker.results.optional.find(r => r.name === 'Node.js version');
       expect(nodeCheck).toBeDefined();
-      // Should always pass as test is running in Node
-      expect(nodeCheck.status).toBe(true);
+      // The gate mirrors engines.node (>=22), so the expected result depends on
+      // the runtime running this suite — it is not a constant. Asserting `true`
+      // silently assumed the old >=18 floor and fails on Node 20.
+      const major = Number(process.versions.node.split('.')[0]);
+      expect(nodeCheck.status).toBe(major >= 22);
     });
   });
 


### PR DESCRIPTION
Closes all four remaining items, plus two bugs found while closing them.

## 1. Node version leftovers

`engines.node` has been `>=22.0.0` since 4.0.0, but the runtime check and the docs never followed.

**`install/post-install-check.js`** gated on `major >= 18`, so Node 18 and 20 **passed a check they should fail**. Gate and both user-facing strings now say 22.

**Eleven docs surfaces** corrected from `>= 16.0.0`/`>= 18.0.0` → `>= 22.0.0`, and the adjacent npm floor `>=8` → `>=10` which was equally stale: installation, contributing, developer-guide, getting-started, troubleshooting, the plugin-development example manifest, `FRAMEWORK-GUIDE.md`, and three plugin READMEs.

Deliberately untouched: `CHANGELOG.md` (records what was true at the time), and Dockerfile examples / CI matrices in plugin docs — those are base images for the *user's* app, not our runtime floor.

## 2. Unused devDependencies

`chai` and `sinon` removed — PR #762 deleted their only consumer. Verified unreferenced across every file type, npm scripts, jest config, all 14 plugin manifests, and the workflows. Nothing else fell unused: `fs-extra` and `yargs` are runtime dependencies with 100 and 322 references respectively.

## 3. docs-site 404s

`config.ts` referenced `/favicon.ico` and `/logo.svg`; neither exists, and an exhaustive search found **no genuine brand asset anywhere in the repo** — only screencast GIFs. Rather than fabricate a logo, both references are removed so nothing 404s, with a comment on how to restore them.

**Worth recording:** `base` is **not** prepended to raw `head` tags but **is** prepended to `themeConfig.logo`. So simply creating the two files would have left the favicon still 404ing at `/favicon.ico` while the logo resolved fine. The restore comment spells out that asymmetry so the next person doesn't hit it.

## 4. Canary review gate — no change needed

`copilot-review-canary.yml` **does not exist** in the working tree, on `main`, or anywhere in git history. Its only two runs were in June on a since-deleted `pilot/canary-review-gate` branch. GitHub retains the workflow record because runs exist, but there is no file to execute — enabling it would be a literal no-op. It is required by no branch protection and blocks nothing.

---

## Two bugs found while closing the above

**A test that had silently become wrong.** `test/jest-tests/post-install-check-jest.test.js` asserted `expect(nodeCheck.status).toBe(true)` with the comment *"Should always pass as test is running in Node"*. That assumed the old `>=18` floor and becomes false on Node 20 once the gate moves to 22. It now derives the expectation from `process.versions.node`, so it is correct on any runtime. The file sits outside the default `testMatch`, so `npm test` never ran it — which is why it went unnoticed.

**Five stale version claims.** Docs still advertised "ClaudeAutoPM v3.14.0" while the release is 4.0.0 — including the home page hero, currently live on the site.

## Verification

- Bare `npm ci`: exit 0
- `npm audit`: **0 vulnerabilities**
- Full suite: **58 suites, 1671 tests passing**
- The previously-unrun `post-install-check` suite: **41 tests passing** on Node 20
- `vitepress build`: 13.7s, **zero references to missing assets**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLJiSBnzwTaotvHA4VZP2W
