### PR TITLE
Promote develop to main

### DIFF
--- a/FRAMEWORK-GUIDE.md
+++ b/FRAMEWORK-GUIDE.md
@@ -184,8 +184,8 @@ After ClaudeAutoPM:
 
 ### Prerequisites
 
-- **Node.js**: >= 16.0.0
-- **npm**: >= 8.0.0
+- **Node.js**: >= 22.0.0
+- **npm**: >= 10.0.0
 - **Git**: Latest version
 - **Claude Code**: Desktop app or CLI access
 - **Docker** (optional): For containerized development

--- a/docs-site/docs/.vitepress/config.ts
+++ b/docs-site/docs/.vitepress/config.ts
@@ -8,13 +8,15 @@ export default defineConfig({
   // Without this every absolute asset and link 404s in production.
   base: '/ClaudeAutoPM/',
 
-  head: [
-    ['link', { rel: 'icon', href: '/favicon.ico' }]
-  ],
+  // No favicon/logo asset ships with this repo, so the previous
+  // head icon link and themeConfig.logo both 404'd in production.
+  // To restore: drop the real files into docs-site/docs/public/ and re-add
+  //   head: [['link', { rel: 'icon', href: '/ClaudeAutoPM/favicon.ico' }]]
+  //   themeConfig.logo: '/logo.svg'
+  // Note the asymmetry: `base` is NOT prepended to raw `head` tags (spell it
+  // out there), but IS prepended to themeConfig.logo (keep that root-relative).
 
   themeConfig: {
-    logo: '/logo.svg',
-
     nav: [
       { text: 'Guide', link: '/getting-started/' },
       { text: 'User Guide', link: '/user-guide/' },

--- a/docs-site/docs/developer-guide/architecture.md
+++ b/docs-site/docs/developer-guide/architecture.md
@@ -1,17 +1,17 @@
 ---
 title: Architecture
-description: ClaudeAutoPM v3.14.0 project architecture, plugin system, providers, and XML rules
+description: ClaudeAutoPM v4.0.0 project architecture, plugin system, providers, and XML rules
 ---
 
 # Project Architecture
 
-ClaudeAutoPM v3.14.0 follows a plugin-based architecture with 13 npm packages, a provider router for issue tracking, and an XML rules system for token-efficient context loading.
+ClaudeAutoPM v4.0.0 follows a plugin-based architecture with 13 npm packages, a provider router for issue tracking, and an XML rules system for token-efficient context loading.
 
 ## High-Level Overview
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
-│                     ClaudeAutoPM v3.14.0                        │
+│                     ClaudeAutoPM v4.0.0                         │
 ├─────────────────────────────────────────────────────────────────┤
 │  CLI Layer (bin/)                                               │
 │  ├── autopm.js (main entry point)                               │

--- a/docs-site/docs/developer-guide/contributing.md
+++ b/docs-site/docs/developer-guide/contributing.md
@@ -56,8 +56,8 @@ Want to contribute?
 
 ### Prerequisites
 
-- Node.js >= 16.0.0
-- npm >= 8.0.0
+- Node.js >= 22.0.0
+- npm >= 10.0.0
 - Git
 - Claude Code CLI (for testing)
 

--- a/docs-site/docs/developer-guide/index.md
+++ b/docs-site/docs/developer-guide/index.md
@@ -84,8 +84,8 @@ Use specialized agents for complex tasks rather than direct tool calls:
 
 ### Prerequisites
 
-- Node.js >= 16.0.0
-- npm >= 8.0.0
+- Node.js >= 22.0.0
+- npm >= 10.0.0
 - Git
 - Claude Code CLI (for testing agents)
 

--- a/docs-site/docs/developer-guide/plugin-development.md
+++ b/docs-site/docs/developer-guide/plugin-development.md
@@ -261,7 +261,7 @@ Hook types: `pre-command`, `pre-agent`, `pre-tool`, `wrapper`, `testing`, `docum
     "README.md"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   }
 }
 ```

--- a/docs-site/docs/getting-started/index.md
+++ b/docs-site/docs/getting-started/index.md
@@ -84,8 +84,8 @@ PRD (Requirements) → Epic (Technical Plan) → Tasks → GitHub Issues → Cod
 
 Before you begin, ensure you have:
 
-- **Node.js** >= 16.0.0
-- **npm** >= 8.0.0
+- **Node.js** >= 22.0.0
+- **npm** >= 10.0.0
 - **Git** installed and configured
 - **Claude Code** or compatible AI coding assistant
 - **GitHub CLI** (optional, installed automatically during setup)

--- a/docs-site/docs/getting-started/installation.md
+++ b/docs-site/docs/getting-started/installation.md
@@ -1,11 +1,11 @@
 ---
 title: Installation
-description: Complete installation guide for ClaudeAutoPM v3.14.0 with all scenarios and configuration options
+description: Complete installation guide for ClaudeAutoPM v4.0.0 with all scenarios and configuration options
 ---
 
 # Installation Guide
 
-This guide covers npm/npx installation methods and configuration options for ClaudeAutoPM v3.14.0. For the shell-based installer, see `install/install.sh`.
+This guide covers npm/npx installation methods and configuration options for ClaudeAutoPM v4.0.0. For the shell-based installer, see `install/install.sh`.
 
 ## System Requirements
 
@@ -13,8 +13,8 @@ This guide covers npm/npx installation methods and configuration options for Cla
 
 | Requirement | Minimum Version |
 |-------------|-----------------|
-| Node.js | >= 16.0.0 (>= 18.0.0 recommended; plugins require 18+) |
-| npm | >= 8.0.0 |
+| Node.js | >= 22.0.0 |
+| npm | >= 10.0.0 |
 | Git | Latest stable |
 
 ### Platform Support

--- a/docs-site/docs/index.md
+++ b/docs-site/docs/index.md
@@ -6,7 +6,7 @@ markdownStyles: false
 hero:
   name: "ClaudeAutoPM"
   text: "Plugin-Based AI Project Management"
-  tagline: Ship faster with spec-driven development, 7 core agents, and 13 optional plugins — v3.14.0
+  tagline: Ship faster with spec-driven development, 7 core agents, and 13 optional plugins — v4.0.0
   actions:
     - theme: brand
       text: Get Started

--- a/docs-site/docs/reference/troubleshooting.md
+++ b/docs-site/docs/reference/troubleshooting.md
@@ -85,7 +85,7 @@ npm install -g claude-autopm@latest
 
 **Problem**: `Node.js version not supported` error
 
-**Requirements**: Node.js ≥ 16.0.0, npm ≥ 8.0.0
+**Requirements**: Node.js ≥ 22.0.0, npm ≥ 10.0.0
 
 **Solution**:
 ```bash

--- a/docs-site/docs/user-guide/pm-workflow.md
+++ b/docs-site/docs/user-guide/pm-workflow.md
@@ -1,6 +1,6 @@
 ---
 title: PM Workflow
-description: Complete project management workflow using ClaudeAutoPM v3.14.0 with local, GitHub, and Azure providers.
+description: Complete project management workflow using ClaudeAutoPM v4.0.0 with local, GitHub, and Azure providers.
 ---
 
 # PM Workflow

--- a/install/post-install-check.js
+++ b/install/post-install-check.js
@@ -339,18 +339,18 @@ class PostInstallChecker {
   checkNodeVersion() {
     const version = process.version;
     const major = parseInt(version.split('.')[0].substring(1));
-    const isSupported = major >= 18;
+    const isSupported = major >= 22;
 
     this.results.optional.push({
       name: 'Node.js version',
       status: isSupported,
       message: isSupported
         ? `${version} (supported)`
-        : `${version} (upgrade recommended)`
+        : `${version} (unsupported - requires v22 or higher)`
     });
 
     if (!isSupported) {
-      this.results.nextSteps.push('Upgrade Node.js to v18 or higher');
+      this.results.nextSteps.push('Upgrade Node.js to v22 or higher');
     }
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,6 @@
         "@types/jest": "^30.0.0",
         "axios": "^1.12.2",
         "c8": "^12.0.0",
-        "chai": "^6.0.1",
         "eslint": "^10.6.0",
         "globals": "^17.6.0",
         "jest": "^30.1.3",
@@ -56,8 +55,7 @@
         "jest-watch-typeahead": "^3.0.1",
         "markdownlint-cli": "^0.49.0",
         "nock": "^14.0.10",
-        "prettier": "^3.0.0",
-        "sinon": "^22.0.0"
+        "prettier": "^3.0.0"
       },
       "engines": {
         "node": ">=22.0.0",
@@ -2361,27 +2359,6 @@
         "@sinonjs/commons": "^3.0.1"
       }
     },
-    "node_modules/@sinonjs/samsam": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-10.0.2.tgz",
-      "integrity": "sha512-8lVwD1Df1BmzoaOLhMcGGcz/Jyr5QY2KSB75/YK1QgKzoabTeLdIVyhXNZK9ojfSKSdirbXqdbsXXqP9/Ve8+A==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sinonjs/commons": "^3.0.1",
-        "type-detect": "^4.1.0"
-      }
-    },
-    "node_modules/@sinonjs/samsam/node_modules/type-detect": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
-      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/@stablelib/base64": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
@@ -3691,16 +3668,6 @@
         }
       ],
       "license": "CC-BY-4.0"
-    },
-    "node_modules/chai": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
-      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -9622,33 +9589,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/steveukx/git-js?sponsor=1"
-      }
-    },
-    "node_modules/sinon": {
-      "version": "22.1.0",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-22.1.0.tgz",
-      "integrity": "sha512-n1ajF2rBWMTtEwbKcw4UdFg4nCnDdq/U6RDoxtOd7oapOlRoJ5ynwFx60owROyhDpA9QhMZi0pCO/xtmwFjG7w==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sinonjs/commons": "^3.0.1",
-        "@sinonjs/fake-timers": "^15.4.0",
-        "@sinonjs/samsam": "^10.0.2",
-        "diff": "^9.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/sinon"
-      }
-    },
-    "node_modules/sinon/node_modules/diff": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
-      "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
       }
     },
     "node_modules/slash": {

--- a/package.json
+++ b/package.json
@@ -160,7 +160,6 @@
     "@types/jest": "^30.0.0",
     "axios": "^1.12.2",
     "c8": "^12.0.0",
-    "chai": "^6.0.1",
     "eslint": "^10.6.0",
     "globals": "^17.6.0",
     "jest": "^30.1.3",
@@ -171,8 +170,7 @@
     "jest-watch-typeahead": "^3.0.1",
     "markdownlint-cli": "^0.49.0",
     "nock": "^14.0.10",
-    "prettier": "^3.0.0",
-    "sinon": "^22.0.0"
+    "prettier": "^3.0.0"
   },
   "optionalDependencies": {
     "@playwright/mcp": "^0.0.79",

--- a/packages/plugin-ai/README.md
+++ b/packages/plugin-ai/README.md
@@ -274,8 +274,8 @@ with mlflow.start_run():
 
 ## Requirements
 
-- **Node.js**: >=16.0.0
-- **npm**: >=8.0.0
+- **Node.js**: >=22.0.0
+- **npm**: >=10.0.0
 - **Python**: >=3.8 (for example scripts)
 - **API Keys**: OpenAI, Gemini (as needed)
 

--- a/packages/plugin-core/README.md
+++ b/packages/plugin-core/README.md
@@ -252,7 +252,7 @@ No configuration needed - all core features are always enabled.
 ## Compatibility
 
 - **Minimum ClaudeAutoPM version:** 3.0.0
-- **Node.js:** >= 18.0.0
+- **Node.js:** >= 22.0.0
 - **Platform:** Cross-platform (macOS, Linux, Windows)
 
 ---

--- a/packages/plugin-pm/README.md
+++ b/packages/plugin-pm/README.md
@@ -359,7 +359,7 @@ MIT © ClaudeAutoPM Team
 
 ## 🎯 Compatibility
 
-- **Node.js:** >= 16.0.0
+- **Node.js:** >= 22.0.0
 - **ClaudeAutoPM:** >= 3.0.0
 - **Plugin Core:** ^2.0.0
 

--- a/test/jest-tests/post-install-check-jest.test.js
+++ b/test/jest-tests/post-install-check-jest.test.js
@@ -398,8 +398,11 @@ describe('PostInstallChecker', () => {
 
       const nodeCheck = checker.results.optional.find(r => r.name === 'Node.js version');
       expect(nodeCheck).toBeDefined();
-      // Should always pass as test is running in Node
-      expect(nodeCheck.status).toBe(true);
+      // The gate mirrors engines.node (>=22), so the expected result depends on
+      // the runtime running this suite — it is not a constant. Asserting `true`
+      // silently assumed the old >=18 floor and fails on Node 20.
+      const major = Number(process.versions.node.split('.')[0]);
+      expect(nodeCheck.status).toBe(major >= 22);
     });
   });
 


### PR DESCRIPTION
Promotion of `develop` → `main`: **1 commit, 18 files** (10 under `docs-site/`).

Carries PR #765 — the cleanup sweep that closed the last four open items.

## What this publishes

The docs corrections in #765 are on `develop` but not yet live. The site currently still serves stale content that this promotion fixes:

- **Node requirements** — pages advertise `>= 16.0.0` / `>= 18.0.0` and `npm >= 8.0.0`, while `engines.node` has been `>=22.0.0` since 4.0.0
- **Version strings** — five surfaces still say "ClaudeAutoPM v3.14.0" against a 4.0.0 release, including the home page hero
- **404ing assets** — `config.ts` referenced a `favicon.ico` and `logo.svg` that don't exist in the repo; both references removed

Also included (non-docs):

- `install/post-install-check.js` gated on `major >= 18`, letting Node 18 and 20 pass a check they should fail
- `chai` and `sinon` removed — unreferenced since #762 deleted their only consumer
- A test asserting `expect(nodeCheck.status).toBe(true)` that had silently become wrong; it now derives the expectation from `process.versions.node`

## Expected effects on merge

1. **`deploy-docs.yml` fires** — 10 changed files under `docs-site/`. Last promotion's deploy succeeded, so the path is known-good.
2. **No npm publish.** `npm-publish.yml` is `v*`-tag triggered; `plugin-publish.yml` is `workflow_dispatch` only. Neither fires from this merge.

## Merge method

Please **merge, not squash** — prior promotions (#624, #669, #688, #764) are merge commits, and squashing would fork `main`'s history from `develop`'s.

## Verification on develop

- Bare `npm ci` (no flags): exit 0
- `npm audit`: 0 vulnerabilities
- Full suite: 58 suites, 1671 tests passing
- `vitepress build`: 13.7s, zero references to missing assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLJiSBnzwTaotvHA4VZP2W
