### PR TITLE
chore(ci): adopt fleet label vocabulary, issue forms and label guard

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,8 +1,38 @@
 name: Bug Report
 description: Something isn't working correctly
 title: "[fix][scope] "
-labels: ["bug", "ai-ready"]
+labels: ["type:bug", "ai-ready"]
 body:
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: "Which part of this repository. Applied as an `area:` label by issue-label-guard."
+      options:
+        - framework
+        - lib
+        - cli
+        - packages
+        - install
+        - scripts
+        - test
+        - docs
+        - ci
+    validations:
+      required: true
+
+  - type: dropdown
+    id: size
+    attributes:
+      label: Size
+      description: "Applied as a `size:` label by issue-label-guard."
+      options:
+        - "S — one sitting"
+        - "M — a day or so"
+        - "L — more than a day (file it as tracking and split it instead)"
+    validations:
+      required: true
+
   - type: textarea
     id: goal
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,8 +1,38 @@
 name: Feature / Enhancement
 description: New feature, improvement, or refactoring task
 title: "[feat][scope] "
-labels: ["enhancement", "ai-ready"]
+labels: ["type:feat", "ai-ready"]
 body:
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: "Which part of this repository. Applied as an `area:` label by issue-label-guard."
+      options:
+        - framework
+        - lib
+        - cli
+        - packages
+        - install
+        - scripts
+        - test
+        - docs
+        - ci
+    validations:
+      required: true
+
+  - type: dropdown
+    id: size
+    attributes:
+      label: Size
+      description: "Applied as a `size:` label by issue-label-guard."
+      options:
+        - "S — one sitting"
+        - "M — a day or so"
+        - "L — more than a day (file it as tracking and split it instead)"
+    validations:
+      required: true
+
   - type: textarea
     id: goal
     attributes:

--- a/.github/workflows/issue-label-guard.yml
+++ b/.github/workflows/issue-label-guard.yml
@@ -1,0 +1,54 @@
+name: issue-label-guard
+on:
+  issues:
+    types: [opened, reopened]
+permissions:
+  issues: write
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const n = context.issue.number;
+            const body = issue.body || '';
+            let have = issue.labels.map(l => l.name);
+
+            // 1. Adopt the issue form's own dropdown answers, if it was form-filed.
+            //    Only a value the filer explicitly selected, and only if that exact
+            //    label already exists here. Never inferred from prose.
+            const section = h => {
+              const m = body.match(new RegExp('###\\s+' + h + '\\s*\\n+([^\\n]+)', 'i'));
+              const v = m && m[1].trim();
+              return (!v || v === '_No response_') ? null : v.split(/\s/)[0].trim();
+            };
+            const wanted = [];
+            const area = section('Area'); if (area) wanted.push('area:' + area);
+            const size = section('Size'); if (size) wanted.push('size:' + size);
+
+            if (wanted.length) {
+              const existing = await github.paginate(
+                github.rest.issues.listLabelsForRepo, { ...context.repo, per_page: 100 });
+              const names = new Set(existing.map(l => l.name));
+              const add = wanted.filter(w => names.has(w) && !have.includes(w));
+              if (add.length) {
+                await github.rest.issues.addLabels(
+                  { ...context.repo, issue_number: n, labels: add });
+                have = have.concat(add);
+              }
+            }
+
+            // 2. Whatever is still missing becomes a loud, visible gap.
+            const missing = ['type:', 'area:', 'size:']
+              .filter(p => !have.some(x => x.startsWith(p)))
+              .map(p => p.slice(0, -1));
+            if (!missing.length) return;
+            await github.rest.issues.addLabels({ ...context.repo, issue_number: n,
+              labels: ['needs-triage'] });
+            await github.rest.issues.createComment({ ...context.repo, issue_number: n,
+              body: `This issue is missing: **${missing.join(', ')}**.\n\n` +
+                    `Unlabelled issues do not appear in the fleet's backlog queries at ` +
+                    `all — they are skipped, not flagged. Add the missing labels and ` +
+                    `remove \`needs-triage\`. See \`CLAUDE.md\` -> Labels.`});

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,26 @@ See `.claude/rules/` for reference:
 - `frontmatter-operations.md` — YAML frontmatter read/write/strip
 - `git-strategy.md` — Branch naming, commit standards, merge workflow
 
+## Labels
+
+Every issue opened here carries `type:`, `area:` and `size:` **at creation** — including
+issues filed by `gh issue create` or the REST API, neither of which picks up issue forms.
+
+- `type:` — `feat`, `bug`, `chore`, `infra`, `spike`, `docs`
+- `area:` — `framework` (autopm/), `lib`, `cli` (bin/), `packages`, `install`, `scripts`,
+  `test`, `docs` (docs/ + docs-site/), `ci` (.github/)
+- `size:` — `S` one sitting, `M` a day or so, `L` more than a day (split it first)
+
+An epic also carries `tracking`, and is never dispatched to a worker.
+`needs-split`, `not-code` and `tracking` all mean **do not dispatch**.
+
+No space after the colon: `size:M`, never `size: M` — a cross-repo query against the
+spaced form returns an empty set, which looks exactly like a backlog with nothing in it.
+
+These exist because dispatching the wrong issue is expensive: an unlabelled epic once
+produced seven issues in one 3,074-line PR, three of them in no sprint at all.
+`.github/workflows/issue-label-guard.yml` applies `needs-triage` to anything filed without them.
+
 ## PROJECT
 
 - **Language**: JavaScript/Node.js


### PR DESCRIPTION
Adds the fleet-wide label vocabulary to this repository and makes it stick for issues filed by every path — issue forms, `gh issue create`, and the REST API.

## In this commit

| File | Change |
|---|---|
| `CLAUDE.md` | New `## Labels` section (~18 lines) — the rule, the three prefixes, and why |
| `.github/ISSUE_TEMPLATE/feature.yml` | **Merged**, not replaced: added required `Area` + `Size` dropdowns; `labels:` now `["type:feat", "ai-ready"]` |
| `.github/ISSUE_TEMPLATE/bug.yml` | Same merge; `labels:` now `["type:bug", "ai-ready"]` |
| `.github/ISSUE_TEMPLATE/config.yml` | New — `blank_issues_enabled: false` |
| `.github/workflows/issue-label-guard.yml` | New — adopts form dropdown answers, then flags what is still missing |

All existing form fields (Goal, Context, Acceptance Criteria, Affected Files, Out of Scope, Definition of Done, …) are preserved unchanged.

## Labels created (API, not commits)

**Vocabulary — 15, all new, none previously existed in any spelling:**
`type:feat` `type:bug` `type:chore` `type:infra` `type:spike` `type:docs` · `size:S` `size:M` `size:L` · `tracking` `needs-split` `split-from` `not-code` `blocked` `needs-triage`

**`area:` — 9, derived from this repository's top-level tree:**

| Label | Directory | Files |
|---|---|---|
| `area:framework` | `autopm/` — the `.claude` payload copied on install | 387 |
| `area:lib` | `lib/` — services, providers, engines | 51 |
| `area:cli` | `bin/` — CLI entry points | 7 |
| `area:packages` | `packages/` — plugins | 535 |
| `area:install` | `install/` — installer, scenario configs | 12 |
| `area:scripts` | `scripts/` — maintenance and sync scripts | 47 |
| `area:test` | `test/` | 412 |
| `area:docs` | `docs/` + `docs-site/` | 154 |
| `area:ci` | `.github/` | 15 |

`examples/` (4 files) and `audits/` (5 files) were deliberately not given areas — neither is a dispatch target.

## Labels migrated or deleted

**None.** No spelling variants of the vocabulary exist here (no `type:feature`, no `size: M`, no `size:m`), so there was nothing to migrate and **nothing was deleted**.

## Issues relabelled

One open issue, labelled by hand:

- **#604** *Refactor: full-repository code unification & deduplication* → `type:chore`, `size:L`, `tracking`, `area:framework`, `area:lib`, `area:packages`, `area:install`, `area:scripts`

It is plainly an epic — it enumerates seven concrete duplication findings across five directories — so it carries `tracking` and must not be dispatched to a worker.

## Deletion candidates — left in place, owner's call

Pre-existing labels whose *meaning* overlaps the vocabulary. Per the rules these are **not** spelling variants and were left alone:

- `bug` → overlaps `type:bug`
- `enhancement` → overlaps `type:feat`
- `documentation` → overlaps `type:docs`
- `epic` → overlaps `tracking`
- `effort:S` / `effort:M` / `effort:L` → overlap `size:S` / `size:M` / `size:L`

`effort:XL` has no equivalent in the vocabulary and was left alone with no substitute invented.

No label in this repository is read by automation: `grep -i label` across `.github/workflows/` returns nothing, so none of the above is a queue trigger or merge gate. The apparent hits for `bug`, `epic`, `task` etc. in `lib/` and `scripts/` are English-word substrings in source (e.g. `debug`), not label references.

## Labels left alone (no equivalent in the vocabulary)

`duplicate` `invalid` `question` `wontfix` `good first issue` `help wanted` `dependencies` `github_actions` `javascript` `prd` `task` `future` `backlog` `phase3` `phase1-standalone` `standalone` `ai-ready` `high-priority` `in-progress` `epic:plugin-obsidian` `copilot-review-unavailable` `effort:XL`

## Note on the guard

GitHub issue forms can only pre-apply a static `labels:` line — dropdown answers land in the issue body. The guard therefore parses the rendered `### Area` / `### Size` sections and applies the matching label **only** when that exact label already exists in the repo, then flags whatever remains. It never infers a label from prose. Accordingly every `Area` option here is a single token matching an `area:` label exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3hBcqmdA2qkGMkMeJ1vrk